### PR TITLE
docs: unify SHACKLE naming, fix install + dead URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# <img src="logo.png" width="48" height="48" align="left" alt="SHACKLE logo" style="margin-right: 12px;"> âï¸ SHACKLE
+# <img src="logo.png" width="48" height="48" align="left" alt="SHACKLE logo" style="margin-right: 12px;"> Ã¢ÂÂÃ¯Â¸Â SHACKLE
 
 [![License: AGPLv3](https://img.shields.io/badge/License-AGPLv3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
@@ -17,23 +17,23 @@ silent infinite loops.
 
 Rather than guessing what the agent ecosystem needed, Sovereign Logic used
 real-time web scraping and community sentiment mining to audit the issue
-trackers of CrewAI, AutoGen, and LangGraph â mapping the exact systemic
+trackers of CrewAI, AutoGen, and LangGraph Ã¢ÂÂ mapping the exact systemic
 failures affecting developers in production, then building the drop-in
 circuit breaker to fix them.
 
-This is infrastructure built by a developer, for developers â sovereign,
+This is infrastructure built by a developer, for developers Ã¢ÂÂ sovereign,
 lean, and zero-bloat.
 
 ---
 
-## ð¯ When to Use SHACKLE
+## Ã°ÂÂÂ¯ When to Use SHACKLE
 
 **SHACKLE is purpose-built for:**
-- **Local development and debugging** â Interactive HITL console gives you real-time control
-- **CLI agents and supervised workflows** â Resume/Skip/Abort when loops are detected
-- **Cross-framework coverage** â One decorator works across CrewAI, LangGraph, and AutoGen
-- **Budget enforcement** â Client-side token tracking prevents runaway costs
-- **Iterative testing** â Catch loops early in the development cycle
+- **Local development and debugging** Ã¢ÂÂ Interactive HITL console gives you real-time control
+- **CLI agents and supervised workflows** Ã¢ÂÂ Resume/Skip/Abort when loops are detected
+- **Cross-framework coverage** Ã¢ÂÂ One decorator works across CrewAI, LangGraph, and AutoGen
+- **Budget enforcement** Ã¢ÂÂ Client-side token tracking prevents runaway costs
+- **Iterative testing** Ã¢ÂÂ Catch loops early in the development cycle
 
 **For headless production APIs** (serverless functions, FastAPI endpoints, background workers where blocking for human input isn't an option), consider framework-native solutions like [TokenCircuit](https://github.com/) for automated LangGraph overrides.
 
@@ -41,13 +41,13 @@ SHACKLE and production-oriented tools solve complementary problems: use SHACKLE 
 
 ---
 
-## â¡ The Problem
+## Ã¢ÂÂ¡ The Problem
 
-AI agents are highly capable, but their error-handling is fundamentally broken. When an agent hits an unhandled tool error (401 Unauthorized, changed API payload, dead endpoint), it rarely self-corrects. Instead, it enters a **"Loop of Death"** â retrying the exact same tool with the exact same input, burning your context window and running up massive API bills in minutes.
+AI agents are highly capable, but their error-handling is fundamentally broken. When an agent hits an unhandled tool error (401 Unauthorized, changed API payload, dead endpoint), it rarely self-corrects. Instead, it enters a **"Loop of Death"** Ã¢ÂÂ retrying the exact same tool with the exact same input, burning your context window and running up massive API bills in minutes.
 
 Frameworks like **CrewAI**, **AutoGen**, and **LangGraph** lack native, framework-agnostic spending guardrails or deterministic loop breakers.
 
-## ð¡ï¸ The Solution
+## Ã°ÂÂÂ¡Ã¯Â¸Â The Solution
 
 SHACKLE is a lightweight, zero-dependency governance layer that sits inside your runtime via dynamic Python shims. It intercepts **LLM calls** and **tool executions** client-side, monitoring execution state deterministically.
 
@@ -55,20 +55,20 @@ When an agent breaches your boundaries, SHACKLE trips the circuit breaker, halts
 
 ### Key Features
 
-- **1-Line Install** â no refactoring your agent topology
-- **Loop of Death Prevention** â detects identical sequential tool calls and error cascades
-- **Budget Enforcement** â real-time token tracking against a client-side pricing table
-- **Execution Timeouts** â prevents hung threads on dead APIs
-- **HITL Console** â interactive terminal with Resume / Skip / Abort options
-- **100% Client-Side** â no telemetry, no phone-home, no hidden SaaS
+- **1-Line Install** Ã¢ÂÂ no refactoring your agent topology
+- **Loop of Death Prevention** Ã¢ÂÂ detects identical sequential tool calls and error cascades
+- **Budget Enforcement** Ã¢ÂÂ real-time token tracking against a client-side pricing table
+- **Execution Timeouts** Ã¢ÂÂ prevents hung threads on dead APIs
+- **HITL Console** Ã¢ÂÂ interactive terminal with Resume / Skip / Abort options
+- **100% Client-Side** Ã¢ÂÂ no telemetry, no phone-home, no hidden SaaS
 
 ---
 
-## ð Quick Start
+## Ã°ÂÂÂ Quick Start
 
 ### 1. Install
 
-> **Note:** the PyPI release is being published. Until `pip install shackle-guard`
+> **Note:** the PyPI release is being published. Until `pip install shackle`
 > is live, install directly from source (works today):
 
 ```bash
@@ -78,7 +78,7 @@ cd SHACKLE
 pip install -e .
 
 # Or, once published to PyPI:
-pip install shackle-guard
+pip install shackle
 ```
 
 ### 2. Guard Your Workflow
@@ -98,11 +98,11 @@ def run():
 run()
 ```
 
-That's it. SHACKLE dynamically hooks the underlying interpreters â no CrewAI source changes needed.
+That's it. SHACKLE dynamically hooks the underlying interpreters Ã¢ÂÂ no CrewAI source changes needed.
 
 ---
 
-## âï¸ The Four Circuit Breakers
+## Ã¢ÂÂÃ¯Â¸Â The Four Circuit Breakers
 
 | Trigger | Condition | Default | What Happens |
 |---|---|---|---|
@@ -113,62 +113,62 @@ That's it. SHACKLE dynamically hooks the underlying interpreters â no CrewA
 
 ### Error Loop Amplification
 
-SHACKLE **amplifies sensitivity** when tool inputs contain error signals (`401`, `500`, `timeout`, `unauthorized`, etc.) â catching the "I'll just try again" loop before the agent burns tokens on a permission error it can't fix.
+SHACKLE **amplifies sensitivity** when tool inputs contain error signals (`401`, `500`, `timeout`, `unauthorized`, etc.) Ã¢ÂÂ catching the "I'll just try again" loop before the agent burns tokens on a permission error it can't fix.
 
 ---
 
-## ð ï¸ The HITL Console
+## Ã°ÂÂÂ Ã¯Â¸Â The HITL Console
 
 When a breaker trips, SHACKLE renders an interactive terminal:
 
 ```
-âï¸ SHACKLE CIRCUIT BREAKER: REPETITIVE_TOOL_CALL
+Ã¢ÂÂÃ¯Â¸Â SHACKLE CIRCUIT BREAKER: REPETITIVE_TOOL_CALL
 
 Agent:         ResearchAgent
 Tool:          web_search
 Input:         {"query": "latest AI news", "error": "401 Unauthorized"}
 Call Count:    3x
-âââ Session Stats âââ
+Ã¢ÂÂÃ¢ÂÂÃ¢ÂÂ Session Stats Ã¢ÂÂÃ¢ÂÂÃ¢ÂÂ
 Tokens:        In: 8,400 | Out: 1,200
 Session Cost:  $0.02850
 Time Running:  47.2s
 
 Options:
-  [R] Resume/Reset â clear history, continue execution
-  [S] Skip â return dummy output, attempt context flush
-  [A] Abort â hard terminate the current run
+  [R] Resume/Reset Ã¢ÂÂ clear history, continue execution
+  [S] Skip Ã¢ÂÂ return dummy output, attempt context flush
+  [A] Abort Ã¢ÂÂ hard terminate the current run
 
 Select action (R/S/A):
 ```
 
 ---
 
-## ð Works With
+## Ã°ÂÂÂ Works With
 
 | Framework | Support | Notes |
 |---|---|---|
-| **CrewAI** | â Full | litellm hook + BaseTool hook + Agent.execute_task (experimental) |
-| **LangChain / LangGraph** | â Full | litellm + BaseTool hooks cover all paths |
-| **AutoGen** | â Full | litellm interception catches all LLM calls |
-| **Smolagents** | ð§ª Experimental | Manager Agent reasoning loop detection active |
+| **CrewAI** | Ã¢ÂÂ Full | litellm hook + BaseTool hook + Agent.execute_task (experimental) |
+| **LangChain / LangGraph** | Ã¢ÂÂ Full | litellm + BaseTool hooks cover all paths |
+| **AutoGen** | Ã¢ÂÂ Full | litellm interception catches all LLM calls |
+| **Smolagents** | Ã°ÂÂ§Âª Experimental | Manager Agent reasoning loop detection active |
 
 ---
 
-## ð V2: Enterprise Runtime Sovereignty Layer (Optional)
+## Ã°ÂÂÂ V2: Enterprise Runtime Sovereignty Layer (Optional)
 
 For production deployments requiring **distributed state**, **compliance audit logs**, or **remote agent control**, see **[v2/README.md](v2/README.md)**.
 
 **V2 adds:**
-- â Distributed budget tracking (across serverless functions, Lambda, K8s)
-- â Postgres audit logs (cryptographically signed, SOC2-ready)
-- â Remote HITL control (manage headless agents from mobile/web)
-- â Commercial licensing (for closed-source products)
+- Ã¢ÂÂ Distributed budget tracking (across serverless functions, Lambda, K8s)
+- Ã¢ÂÂ Postgres audit logs (cryptographically signed, SOC2-ready)
+- Ã¢ÂÂ Remote HITL control (manage headless agents from mobile/web)
+- Ã¢ÂÂ Commercial licensing (for closed-source products)
 
 **V1 (this)** is always free and perfect for local development. **V2** is an optional upgrade for enterprise production use.
 
 ---
 
-## ð® Roadmap
+## Ã°ÂÂÂ® Roadmap
 
 - [x] Budget enforcement (client-side pricing table)
 - [x] Loop of Death detection (repeat tool calls + error amplification)
@@ -183,21 +183,21 @@ For production deployments requiring **distributed state**, **compliance audit l
 
 ---
 
-## ð° Commercial Licensing
+## Ã°ÂÂÂ° Commercial Licensing
 
-SHACKLE is open-source under **AGPLv3** â free for individual developers,
+SHACKLE is open-source under **AGPLv3** Ã¢ÂÂ free for individual developers,
 hobbyists, and open-source projects. If you're using SHACKLE in a closed-source
 commercial product, SaaS platform, or enterprise deployment, the AGPLv3
 requires you to open-source your entire application. Most companies don't
-want to do that â so they purchase a commercial license instead.
+want to do that Ã¢ÂÂ so they purchase a commercial license instead.
 
 ### What a Commercial License Gets You
 
 | | AGPLv3 (Free) | Commercial License |
 |---|---|---|
-| Use in closed-source products | â | â |
-| White-label / rebrand | â | â |
-| No copyleft obligations | â | â |
+| Use in closed-source products | Ã¢ÂÂ | Ã¢ÂÂ |
+| White-label / rebrand | Ã¢ÂÂ | Ã¢ÂÂ |
+| No copyleft obligations | Ã¢ÂÂ | Ã¢ÂÂ |
 | Priority support | Community | SLA-backed |
 | Custom integration assistance | Self-serve | Architecture audit |
 
@@ -210,11 +210,11 @@ Commercial licensing is available for:
 
 Pricing is customized based on your needs, team size, and deployment scale.
 
-ð§ **Contact for pricing:** docspoc101@gmail.com
+Ã°ÂÂÂ§ **Contact for pricing:** docspoc101@gmail.com
 
 ---
 
-## â ï¸ Disclaimer of Liability
+## Ã¢ÂÂ Ã¯Â¸Â Disclaimer of Liability
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
@@ -229,7 +229,7 @@ NON-DETERMINISTIC. SHACKLE IS A BEST-EFFORT CIRCUIT BREAKER AND DOES NOT
 GUARANTEE PREVENTING ALL API SPEND OVERRUNS. YOU REMAIN SOLELY RESPONSIBLE FOR
 MONITORING YOUR OWN API LIMITS AND USAGE BILLS.
 
-## ð License
+## Ã°ÂÂÂ License
 
 Copyright (C) 2026 Dante Bullock, Sovereign Logic.
 
@@ -241,9 +241,9 @@ See [LICENSE](LICENSE) for full terms.
 
 ---
 
-## ð¤ Creator
+## Ã°ÂÂÂ¤ Creator
 
-**Dante Bullock** â 52-year-old self-taught systems architect from Oakland, California.
+**Dante Bullock** Ã¢ÂÂ 52-year-old self-taught systems architect from Oakland, California.
 Founder of Sovereign Logic. Built SHACKLE out of raw necessity after watching
 autonomous agents burn thousands in silent API loops with no native circuit
 breaker in sight.
@@ -256,11 +256,11 @@ Contact: docspoc101@gmail.com
 
 ---
 
-## ð¤ Contributing
+## Ã°ÂÂ¤Â Contributing
 
 ### Pricing Table Updates
 
-As model providers update pricing, submit PRs to `shackle/core.py` â `MODEL_PRICING`. Contributors who submit verified pricing updates get credited in release notes.
+As model providers update pricing, submit PRs to `shackle/core.py` Ã¢ÂÂ `MODEL_PRICING`. Contributors who submit verified pricing updates get credited in release notes.
 
 ### Adding Framework Hooks
 
@@ -272,7 +272,7 @@ SHACKLE's architecture supports pluggable runtime hooks. To add support for a ne
 
 ---
 
-## 💼 Commercial Support (optional)
+## ð¼ Commercial Support (optional)
 
 SHACKLE is free and open source (AGPLv3). If you want hands-on help deploying it
 in your stack, paid implementation and architecture-audit support is available.
@@ -280,14 +280,14 @@ in your stack, paid implementation and architecture-audit support is available.
 **I fix this. Today.**
 
 If your CrewAI / LangGraph / AutoGen agents are burning money in loops and you
-need a solution deployed by someone who understands the internals â not a generic
+need a solution deployed by someone who understands the internals Ã¢ÂÂ not a generic
 consultant who'll Google "what is CrewAI" on your dime:
 
-ð§ **docspoc101@gmail.com**
+Ã°ÂÂÂ§ **docspoc101@gmail.com**
 
-### ð³ Ready to Start? Pay Here
+### Ã°ÂÂÂ³ Ready to Start? Pay Here
 
-**[â Pay $2,500 â SHACKLE Implementation + Architecture Audit â](https://buy.stripe.com/6oU28q54DbsXdpV6Hy9sk00)**
+**[Ã¢ÂÂ Pay $2,500 Ã¢ÂÂ SHACKLE Implementation + Architecture Audit Ã¢ÂÂ](https://buy.stripe.com/6oU28q54DbsXdpV6Hy9sk00)**
 
 *After payment, email docspoc101@gmail.com with your repo link. I'll respond
 within 4 hours to schedule your architecture audit.*

--- a/SP-1.0-SPECIFICATION.md
+++ b/SP-1.0-SPECIFICATION.md
@@ -1,4 +1,4 @@
-# SHACKLE Protocol Specification — SP/1.0
+# SHACKLE Protocol Specification â SP/1.0
 
 ## Runtime Circuit Breaker for Autonomous AI Agents
 
@@ -7,7 +7,7 @@
 **Date:** 2026-06-25  
 **Authors:** Dante Bullock, Sovereign Logic  
 **License:** Creative Commons Attribution 4.0 International (CC-BY 4.0)  
-**Reference Implementation:** <https://github.com/Fame510/SHACKLE-PRO->  
+**Reference Implementation:** <https://github.com/Fame510/SHACKLE>  
 **First Public Commit:** 2026-06-17 23:12 UTC  
 
 > **Implementations of this specification are subject to the SHACKLE license terms.**
@@ -32,14 +32,14 @@ SHACKLE is the **first open-source runtime circuit breaker for AI agents** with 
 
 ### 1.1 The Problem
 
-Autonomous AI agents execute tools — web search, file I/O, API calls, code execution — with no runtime oversight. The framework's recursion limit or token cap is the only guardrail. When an agent enters a retry loop (same tool, same error, burning tokens each time), there is no mechanism to detect, intercept, and stop it before the wallet is empty.
+Autonomous AI agents execute tools â web search, file I/O, API calls, code execution â with no runtime oversight. The framework's recursion limit or token cap is the only guardrail. When an agent enters a retry loop (same tool, same error, burning tokens each time), there is no mechanism to detect, intercept, and stop it before the wallet is empty.
 
 This is not hypothetical. Production deployments have documented:
 - Agent infinite loops consuming $6,000+ in API costs before the recursion limit fired
 - Duplicate tool calls repeating 50+ times with no variation
 - Spawned child processes hanging indefinitely while consuming tokens
 
-The industry consensus — independently reached by multiple teams in June 2026 — is that **generation authority is not release authority.** The model generates candidates. A separate mediation layer must authorize execution.
+The industry consensus â independently reached by multiple teams in June 2026 â is that **generation authority is not release authority.** The model generates candidates. A separate mediation layer must authorize execution.
 
 SHACKLE is that mediation layer.
 
@@ -47,22 +47,22 @@ SHACKLE is that mediation layer.
 
 | Principle | Meaning |
 |-----------|---------|
-| **Deterministic core** | `decide(state, call) → Verdict` is a pure function. Same inputs always produce same outputs. |
+| **Deterministic core** | `decide(state, call) â Verdict` is a pure function. Same inputs always produce same outputs. |
 | **Daemon as authority** | The SHACKLE daemon is the sole source of truth for time, state, and verdicts. Agents are untrusted. |
 | **Append-only audit** | Every decision is Ed25519-signed and written to an immutable audit log. Chain-of-custody is cryptographically verifiable. |
 | **Mathematically verified** | 9 invariant properties hold under all inputs, proven by property-based testing (Hypothesis, 500+ examples each). |
 | **Graceful degradation** | Agents function in local/library mode without a daemon. Distributed state is an upgrade path. |
-| **Fail-closed** | Network failure, daemon crash, or timeout → DENY. No execution without explicit authorization. |
+| **Fail-closed** | Network failure, daemon crash, or timeout â DENY. No execution without explicit authorization. |
 
 ### 1.3 Scope
 
 This specification covers:
-- The decision function and its 9 mathematical invariants (§3)
-- Message schemas and semantics (§4)
-- State model (§5)
-- Transport bindings (§6)
-- Audit and security (§7)
-- Compliance framework (§8)
+- The decision function and its 9 mathematical invariants (Â§3)
+- Message schemas and semantics (Â§4)
+- State model (Â§5)
+- Transport bindings (Â§6)
+- Audit and security (Â§7)
+- Compliance framework (Â§8)
 
 This specification does NOT cover:
 - Daemon persistence layer (implementation detail)
@@ -76,58 +76,58 @@ This specification does NOT cover:
 ### 2.1 Deployment Models
 
 ```
-MODEL A — Library Mode (In-Process)
-┌─────────────────────────┐
-│  Agent Process          │
-│  ┌───────────────────┐  │
-│  │ @Guard decorator  │  │
-│  │ Local state only  │  │
-│  └───────────────────┘  │
-└─────────────────────────┘
+MODEL A â Library Mode (In-Process)
+âââââââââââââââââââââââââââ
+â  Agent Process          â
+â  âââââââââââââââââââââ  â
+â  â @Guard decorator  â  â
+â  â Local state only  â  â
+â  âââââââââââââââââââââ  â
+âââââââââââââââââââââââââââ
 
-MODEL B — Sidecar Daemon (Production)
-┌─────────────────┐     Unix/gRPC      ┌──────────────────────────┐
-│  Agent Process  │ ◄────────────────► │  SHACKLE Daemon          │
-│  ┌───────────┐  │   pre_exec         │  ┌────────────────────┐  │
-│  │ Thin      │  │   post_exec        │  │ Policy Engine      │  │
-│  │ Client    │  │   register         │  │ - Budgets          │  │
-│  │ Shim      │  │   heartbeat        │  │ - Counters         │  │
-│  └───────────┘  │                    │  │ - Circuit Breakers │  │
-└─────────────────┘                    │  └────────────────────┘  │
-                                        │  ┌────────────────────┐  │
-                                        │  │ Audit Log          │  │
-                                        │  │ Ed25519-signed     │  │
-                                        │  │ Append-only        │  │
-                                        │  │ Chain-linked       │  │
-                                        │  └────────────────────┘  │
-                                        └──────────────────────────┘
+MODEL B â Sidecar Daemon (Production)
+âââââââââââââââââââ     Unix/gRPC      ââââââââââââââââââââââââââââ
+â  Agent Process  â ââââââââââââââââââº â  SHACKLE Daemon          â
+â  âââââââââââââ  â   pre_exec         â  ââââââââââââââââââââââ  â
+â  â Thin      â  â   post_exec        â  â Policy Engine      â  â
+â  â Client    â  â   register         â  â - Budgets          â  â
+â  â Shim      â  â   heartbeat        â  â - Counters         â  â
+â  âââââââââââââ  â                    â  â - Circuit Breakers â  â
+âââââââââââââââââââ                    â  ââââââââââââââââââââââ  â
+                                        â  ââââââââââââââââââââââ  â
+                                        â  â Audit Log          â  â
+                                        â  â Ed25519-signed     â  â
+                                        â  â Append-only        â  â
+                                        â  â Chain-linked       â  â
+                                        â  ââââââââââââââââââââââ  â
+                                        ââââââââââââââââââââââââââââ
 
-MODEL C — Distributed (Enterprise)
-┌──────────┐  ┌──────────┐  ┌──────────┐
-│ Agent A  │  │ Agent B  │  │ Agent C  │
-└────┬─────┘  └────┬─────┘  └────┬─────┘
-     └─────────────┬─────────────┘
-                   │  gRPC/TLS
-          ┌────────┴────────┐
-          │  SHACKLE        │
-          │  Daemon Cluster │
-          │  Redis (state)  │
-          │  Postgres (logs)│
-          └─────────────────┘
+MODEL C â Distributed (Enterprise)
+ââââââââââââ  ââââââââââââ  ââââââââââââ
+â Agent A  â  â Agent B  â  â Agent C  â
+ââââââ¬ââââââ  ââââââ¬ââââââ  ââââââ¬ââââââ
+     âââââââââââââââ¬ââââââââââââââ
+                   â  gRPC/TLS
+          ââââââââââ´âââââââââ
+          â  SHACKLE        â
+          â  Daemon Cluster â
+          â  Redis (state)  â
+          â  Postgres (logs)â
+          âââââââââââââââââââ
 ```
 
 ### 2.2 Protocol Layers
 
 ```
-┌──────────────────────────────────┐
-│    Policy Language (future)      │  ← DSL for guard rules
-├──────────────────────────────────┤
-│    Decision Function             │  ← decide(state, call) → Verdict
-├──────────────────────────────────┤
-│    Message Protocol              │  ← This specification
-├──────────────────────────────────┤
-│    Transport (Unix/gRPC/WS)      │  ← Binding layer
-└──────────────────────────────────┘
+ââââââââââââââââââââââââââââââââââââ
+â    Policy Language (future)      â  â DSL for guard rules
+ââââââââââââââââââââââââââââââââââââ¤
+â    Decision Function             â  â decide(state, call) â Verdict
+ââââââââââââââââââââââââââââââââââââ¤
+â    Message Protocol              â  â This specification
+ââââââââââââââââââââââââââââââââââââ¤
+â    Transport (Unix/gRPC/WS)      â  â Binding layer
+ââââââââââââââââââââââââââââââââââââ
 ```
 
 ---
@@ -136,7 +136,7 @@ MODEL C — Distributed (Enterprise)
 
 ### 3.1 Core Function
 
-The decision function is the heart of SHACKLE. It is a pure function — no I/O, no side effects, no allocations in the hot path. It is human-auditable in under 10 minutes. It is under 200 lines of logic.
+The decision function is the heart of SHACKLE. It is a pure function â no I/O, no side effects, no allocations in the hot path. It is human-auditable in under 10 minutes. It is under 200 lines of logic.
 
 ```
 function decide(
@@ -144,30 +144,30 @@ function decide(
     call: ToolCall,
     config: GuardConfig,
     rng_float: float
-) → Verdict
+) â Verdict
 ```
 
-### 3.2 Decision Algorithm — 8 Stacked Layers
+### 3.2 Decision Algorithm â 8 Stacked Layers
 
 ```
 Layer 1: Circuit Breaker
     IF state.circuit_tripped:
-        → DENY(CIRCUIT_OPEN)
+        â DENY(CIRCUIT_OPEN)
 
 Layer 2: Nonce Validation (Anti-Replay)
     IF call.nonce IN state.seen_nonces:
-        → DENY(POLICY_VIOLATION)
+        â DENY(POLICY_VIOLATION)
 
 Layer 3: Budget Guard
     IF config.budget_usd > 0:
         IF state.budget_remaining_usd <= 0:
-            → DENY(BUDGET_EXHAUSTED)
+            â DENY(BUDGET_EXHAUSTED)
         IF hitl_mode == ON_THRESHOLD AND fraction <= threshold:
-            → HITL("budget threshold reached")
+            â HITL("budget threshold reached")
         IF call.cost > state.budget_remaining:
             IF hitl_mode IN (ON_DENY, ALWAYS):
-                → HITL("cost exceeds remaining budget")
-            → DENY(BUDGET_EXHAUSTED)
+                â HITL("cost exceeds remaining budget")
+            â DENY(BUDGET_EXHAUSTED)
 
 Layer 4: Repeat Call Guard
     IF config.max_repeat_calls > 0:
@@ -176,28 +176,28 @@ Layer 4: Repeat Call Guard
             IF error_amplification AND has_error_signal(call):
                 limit = max(1, limit - 1)
             IF repeat_count >= limit:
-                → DENY(MAX_REPEAT_EXCEEDED)
+                â DENY(MAX_REPEAT_EXCEEDED)
 
 Layer 5: Time Window Guard
     IF config.window_max_calls > 0:
         IF window_count >= window_max_calls:
-            → DENY(WINDOW_EXCEEDED)
+            â DENY(WINDOW_EXCEEDED)
 
 Layer 6: Global Call Limit
     IF config.max_total_calls > 0 AND total_calls >= max_total_calls:
-        → DENY(GLOBAL_LIMIT)
+        â DENY(GLOBAL_LIMIT)
 
 Layer 7: Probabilistic Denial (Adversarial Hardening)
     IF probabilistic_deny AND budget_ratio < 0.2:
         IF rng < deny_jitter_ratio * (1.0 - budget_ratio):
-            → DENY(BUDGET_EXHAUSTED, probabilistic=true)
+            â DENY(BUDGET_EXHAUSTED, probabilistic=true)
 
 Layer 8: HITL Always
     IF hitl_mode == ALWAYS:
-        → HITL("HITL required for all calls")
+        â HITL("HITL required for all calls")
 
 Default:
-    → ALLOW
+    â ALLOW
 ```
 
 ### 3.3 Mathematical Invariants (Must Hold Under All Inputs)
@@ -206,15 +206,15 @@ These 9 properties are verified by property-based testing (Hypothesis, Python) w
 
 | # | Property | Formal Statement |
 |---|----------|-----------------|
-| **P1** | Budget monotonically non-increasing | ∀ calls: budget_after ≤ budget_before |
-| **P2** | Repeat counts non-decreasing | ∀ tool: repeat_count never decreases |
-| **P3** | Once tripped, always tripped | circuit_tripped ⇒ all subsequent verdicts = DENY |
-| **P4** | Budget never negative | budget_remaining ≥ 0 |
-| **P5** | Repeat limit triggers DENY | repeat_count ≥ max_repeat_calls ⇒ verdict = DENY |
-| **P6** | Fresh state ALLOWs first call | fresh SessionState + any ToolCall ⇒ ALLOW |
-| **P7** | Deterministic output | identical (state, call, config, rng) ⇒ identical Decision |
-| **P8** | HITL_ALWAYS produces HITL | hitl_mode = ALWAYS ∧ ¬circuit_tripped ⇒ verdict = HITL |
-| **P9** | Nonce uniqueness enforced | duplicate nonce ⇒ DENY |
+| **P1** | Budget monotonically non-increasing | â calls: budget_after â¤ budget_before |
+| **P2** | Repeat counts non-decreasing | â tool: repeat_count never decreases |
+| **P3** | Once tripped, always tripped | circuit_tripped â all subsequent verdicts = DENY |
+| **P4** | Budget never negative | budget_remaining â¥ 0 |
+| **P5** | Repeat limit triggers DENY | repeat_count â¥ max_repeat_calls â verdict = DENY |
+| **P6** | Fresh state ALLOWs first call | fresh SessionState + any ToolCall â ALLOW |
+| **P7** | Deterministic output | identical (state, call, config, rng) â identical Decision |
+| **P8** | HITL_ALWAYS produces HITL | hitl_mode = ALWAYS â§ Â¬circuit_tripped â verdict = HITL |
+| **P9** | Nonce uniqueness enforced | duplicate nonce â DENY |
 
 ### 3.4 Verdict Types
 
@@ -229,7 +229,7 @@ These 9 properties are verified by property-based testing (Hypothesis, Python) w
 | Reason | Trigger |
 |--------|---------|
 | `CIRCUIT_OPEN` | Circuit breaker was previously tripped |
-| `BUDGET_EXHAUSTED` | Budget remaining ≤ 0 or cost > remaining |
+| `BUDGET_EXHAUSTED` | Budget remaining â¤ 0 or cost > remaining |
 | `MAX_REPEAT_EXCEEDED` | Same tool + same params repeated too many times |
 | `WINDOW_EXCEEDED` | Too many calls in the current time window |
 | `GLOBAL_LIMIT` | Session-wide call limit reached |
@@ -248,16 +248,16 @@ Error signals: 401, unauthorized, 403, forbidden, 500, 502, 503,
                resource exhausted, deadline exceeded
 ```
 
-This catches the "loop of death" — agent hits 401, retries, gets 401, retries — without waiting for the full repeat threshold.
+This catches the "loop of death" â agent hits 401, retries, gets 401, retries â without waiting for the full repeat threshold.
 
 ### 3.7 Probabilistic Denial (Adversarial Hardening)
 
 When `probabilistic_deny` is enabled and the agent is below 20% budget, a random factor is introduced:
 
 ```
-probability = deny_jitter_ratio × (1.0 − budget_ratio)
+probability = deny_jitter_ratio Ã (1.0 â budget_ratio)
 IF rng < probability:
-    → DENY (appears as BUDGET_EXHAUSTED)
+    â DENY (appears as BUDGET_EXHAUSTED)
 ```
 
 This prevents adversarial agents from probing the exact budget threshold and gaming it. The denial appears identical to a real budget exhaustion, making it impossible to distinguish signal from noise.
@@ -360,7 +360,7 @@ message PostExecNotification {
 
 ### 4.5 Heartbeat
 
-Agents SHOULD send heartbeats every 30 seconds. 3 consecutive missed heartbeats → session marked STALE.
+Agents SHOULD send heartbeats every 30 seconds. 3 consecutive missed heartbeats â session marked STALE.
 
 ```protobuf
 message Heartbeat {
@@ -409,8 +409,8 @@ message SessionState {
 
   // Counters
   uint64 total_calls = 20;
-  map<string, uint32> repeat_counts = 21;   // tool_name → consecutive identical calls
-  map<string, uint32> window_counts = 22;   // tool_name → calls in current window
+  map<string, uint32> repeat_counts = 21;   // tool_name â consecutive identical calls
+  map<string, uint32> window_counts = 22;   // tool_name â calls in current window
 
   // Circuit
   bool circuit_tripped = 30;
@@ -463,11 +463,11 @@ message GuardConfig {
 
   // Adversarial hardening
   bool probabilistic_deny = 50;
-  double deny_jitter_ratio = 51;      // 0.0–1.0
+  double deny_jitter_ratio = 51;      // 0.0â1.0
 
   // HITL
   HitlMode hitl_mode = 60;            // NEVER | ON_DENY | ON_THRESHOLD | ALWAYS
-  double hitl_budget_threshold = 61;  // 0.0–1.0
+  double hitl_budget_threshold = 61;  // 0.0â1.0
 
   // Hierarchy
   string parent_guard_id = 70;        // For nested guard trees
@@ -513,7 +513,7 @@ SLA:        5ms for pre_exec, 1s for register
 
 ```
 Endpoint:   grpc://localhost:9000 or grpcs:// for TLS
-Service:    ShackleDaemon (see §4.6)
+Service:    ShackleDaemon (see Â§4.6)
 Auth:       mTLS with client certificates
 SLA:        5ms for pre_exec, 1s for register
 ```
@@ -548,7 +548,7 @@ message AuditEntry {
   double budget_before_usd = 11;
   double budget_after_usd = 12;
   string operator_id = 13;           // Human operator if HITL override
-  bytes signature = 14;              // Ed25519 over fields 1–13
+  bytes signature = 14;              // Ed25519 over fields 1â13
   bytes previous_entry_hash = 15;    // Chain-link to previous entry
 }
 ```
@@ -576,12 +576,12 @@ message AuditEntry {
 
 | Threat | Mitigation |
 |--------|-----------|
-| Replay attack | Nonce per call; daemon tracks seen nonces (§3.2, Layer 2) |
-| Identity spoofing | Registration with org-level auth (§4.2) |
+| Replay attack | Nonce per call; daemon tracks seen nonces (Â§3.2, Layer 2) |
+| Identity spoofing | Registration with org-level auth (Â§4.2) |
 | Clock manipulation | Daemon is sole time authority; client timestamps are informational |
-| Budget drift | Heartbeat sync with authoritative state (§4.5) |
-| Adversarial probing | Probabilistic denial near thresholds (§3.7) |
-| Audit tampering | Append-only file; Ed25519 signatures; chain-linked entries (§7.2) |
+| Budget drift | Heartbeat sync with authoritative state (Â§4.5) |
+| Adversarial probing | Probabilistic denial near thresholds (Â§3.7) |
+| Audit tampering | Append-only file; Ed25519 signatures; chain-linked entries (Â§7.2) |
 | DoS | Rate limiting per session; message size cap (1MB) |
 | Protocol parser exploits | Separate process for parsing; seccomp sandbox |
 
@@ -606,17 +606,17 @@ message AuditEntry {
 | **CC6.3** Security Incidents | Circuit breaker trip events | AuditEntry with DENY verdict |
 | **CC7.2** System Monitoring | Heartbeat + drift detection | Heartbeat/HeartbeatAck messages |
 | **CC7.3** Incident Response | HITL console with operator audit trail | operator_id in AuditEntry |
-| **CC8.1** Change Management | Version negotiation + LTS policy | §9 |
+| **CC8.1** Change Management | Version negotiation + LTS policy | Â§9 |
 | **A1.2** Availability | Timeout enforcement | timeout_seconds in GuardConfig |
 | **C1.1** Confidentiality | On-premise daemon, no telemetry | Model B/C deployment; local-only |
-| **PI1.3** Processing Integrity | Deterministic decision function | §3.3 properties P1–P9 |
+| **PI1.3** Processing Integrity | Deterministic decision function | Â§3.3 properties P1âP9 |
 
 ### 8.2 Standards Compliance
 
 SHACKLE audit logs are designed to satisfy:
 - **SOC2 Type II** auditor requests
 - **ISO 27001** Annex A.12.4 (Logging and Monitoring)
-- **GDPR Article 30** (Records of Processing) — for agent actions on personal data
+- **GDPR Article 30** (Records of Processing) â for agent actions on personal data
 - **Cyber insurance** underwriting requirements
 
 ---
@@ -647,12 +647,12 @@ Protocol versions follow SemVer: `MAJOR.MINOR.PATCH`
 ### 9.4 Negotiation
 
 ```
-Client → Daemon: protocol_version = "1.2.0"
+Client â Daemon: protocol_version = "1.2.0"
 Daemon checks:   can support up to 1.0.0
-Daemon → Client: negotiated_protocol = "1.0.0"
+Daemon â Client: negotiated_protocol = "1.0.0"
 ```
 
-No compatible version → Error with code `PROTOCOL_VERSION_MISMATCH`.
+No compatible version â Error with code `PROTOCOL_VERSION_MISMATCH`.
 
 ---
 
@@ -660,17 +660,17 @@ No compatible version → Error with code `PROTOCOL_VERSION_MISMATCH`.
 
 The Python reference implementation lives at:
 
-**<https://github.com/Fame510/SHACKLE-PRO->**
+**<https://github.com/Fame510/SHACKLE>**
 
 | Component | File | Status |
 |-----------|------|--------|
-| Decision function | `v2/spec/decide.py` | ✅ Production (187 lines) |
-| Property-based tests | `v2/tests/test_decide_properties.py` | ✅ 18/18 passing |
-| Protocol definitions | `v2/protocol/shackle.proto` | ✅ Complete |
-| Service definitions | `v2/protocol/shackle_service.proto` | ✅ Complete |
-| CI pipeline | `.github/workflows/ci.yml` | ✅ Configured |
-| TypeScript library | `v2/ts/` | ✅ Published |
-| Docker image | `Dockerfile` | ✅ Multi-stage |
+| Decision function | `v2/spec/decide.py` | â Production (187 lines) |
+| Property-based tests | `v2/tests/test_decide_properties.py` | â 18/18 passing |
+| Protocol definitions | `v2/protocol/shackle.proto` | â Complete |
+| Service definitions | `v2/protocol/shackle_service.proto` | â Complete |
+| CI pipeline | `.github/workflows/ci.yml` | â Configured |
+| TypeScript library | `v2/ts/` | â Published |
+| Docker image | `Dockerfile` | â Multi-stage |
 
 ### 10.1 Quick Start
 
@@ -684,32 +684,32 @@ def my_agent():
     pass
 ```
 
-Install: `pip install git+https://github.com/Fame510/SHACKLE-PRO-.git`
+Install: `pip install git+https://github.com/Fame510/SHACKLE.git`
 
 ---
 
 ## Appendix A: Example Flow
 
 ```
-1.  Agent → Daemon: REGISTER(agent_id="research-bot", framework="crewai")
-2.  Daemon → Agent: REGISTER_RESPONSE(session_id="s_01", config={budget:0.50, max_repeat:3})
+1.  Agent â Daemon: REGISTER(agent_id="research-bot", framework="crewai")
+2.  Daemon â Agent: REGISTER_RESPONSE(session_id="s_01", config={budget:0.50, max_repeat:3})
 
-3.  Agent → Daemon: PRE_EXEC(call=1, tool="web_search", hash=0xDEAD, cost=0.002)
-4.  Daemon → Agent: PRE_EXEC_RESPONSE(verdict=ALLOW, budget_remaining=0.498)
+3.  Agent â Daemon: PRE_EXEC(call=1, tool="web_search", hash=0xDEAD, cost=0.002)
+4.  Daemon â Agent: PRE_EXEC_RESPONSE(verdict=ALLOW, budget_remaining=0.498)
 
 5.  Agent: [executes web_search]
-6.  Agent → Daemon: POST_EXEC(call=1, actual_cost=0.0015, success=true)
+6.  Agent â Daemon: POST_EXEC(call=1, actual_cost=0.0015, success=true)
 
-7.  Agent → Daemon: PRE_EXEC(call=2, tool="web_search", hash=0xDEAD, cost=0.002)
-8.  Daemon → Agent: PRE_EXEC_RESPONSE(verdict=ALLOW, budget_remaining=0.496, repeat_count=1)
+7.  Agent â Daemon: PRE_EXEC(call=2, tool="web_search", hash=0xDEAD, cost=0.002)
+8.  Daemon â Agent: PRE_EXEC_RESPONSE(verdict=ALLOW, budget_remaining=0.496, repeat_count=1)
 
     ... agent repeats 2 more times ...
 
-9.  Agent → Daemon: PRE_EXEC(call=4, tool="web_search", hash=0xDEAD, cost=0.002)
-10. Daemon → Agent: PRE_EXEC_RESPONSE(verdict=DENY, reason=MAX_REPEAT_EXCEEDED, repeat_count=3)
+9.  Agent â Daemon: PRE_EXEC(call=4, tool="web_search", hash=0xDEAD, cost=0.002)
+10. Daemon â Agent: PRE_EXEC_RESPONSE(verdict=DENY, reason=MAX_REPEAT_EXCEEDED, repeat_count=3)
 
 11. Daemon: [writes AuditEntry to append-only log]
-12. Daemon: [trips circuit breaker for session — all subsequent calls DENY]
+12. Daemon: [trips circuit breaker for session â all subsequent calls DENY]
 ```
 
 ---
@@ -735,14 +735,14 @@ Install: `pip install git+https://github.com/Fame510/SHACKLE-PRO-.git`
 |------|-----------|
 | **Agent** | An autonomous AI process that executes tools |
 | **Circuit Breaker** | Once tripped, all subsequent calls are DENY |
-| **Daemon** | The SHACKLE server process — sole authority for state and verdicts |
+| **Daemon** | The SHACKLE server process â sole authority for state and verdicts |
 | **Guard** | A configured policy (budget, repeat limit, timeout) applied to an agent |
-| **HITL** | Human-in-the-Loop — manual authorization step |
-| **Nonce** | A number used once — anti-replay mechanism |
+| **HITL** | Human-in-the-Loop â manual authorization step |
+| **Nonce** | A number used once â anti-replay mechanism |
 | **Tool Call** | A single invocation of an agent tool (API, file I/O, code exec) |
 | **Verdict** | The decision: ALLOW, DENY, or HITL |
 
 ---
 
-*SP/1.0 — Sovereign Logic, June 2026. Licensed under CC-BY 4.0.*  
+*SP/1.0 â Sovereign Logic, June 2026. Licensed under CC-BY 4.0.*  
 *Reference implementation: AGPLv3 + Commercial. Contact: docspoc101@gmail.com*

--- a/index.html
+++ b/index.html
@@ -3,13 +3,13 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>SHACKLE — Runtime Circuit Breaker for Autonomous AI Agents</title>
+<title>SHACKLE â Runtime Circuit Breaker for Autonomous AI Agents</title>
 <meta name="description" content="The 1-Line Runtime Circuit Breaker for Autonomous AI Agents. Stop runaway token loops before they burn your wallet. Built by Dante Bullock, Sovereign Logic.">
 <style>
-  /* ═══════════════════════════════════════════════════════════
-     SHACKLE — BRUTALIST DEFENSE-GRADE INDUSTRIAL
+  /* âââââââââââââââââââââââââââââââââââââââââââââââââââââââââââ
+     SHACKLE â BRUTALIST DEFENSE-GRADE INDUSTRIAL
      Black box flight recorder for the AI age.
-     ═══════════════════════════════════════════════════════════ */
+     âââââââââââââââââââââââââââââââââââââââââââââââââââââââââââ */
 
   :root {
     --black: #0a0a0a;
@@ -36,9 +36,9 @@
     -webkit-font-smoothing: antialiased;
   }
 
-  /* ═══════════════════════════════════════
-     HERO — Warning Banner
-     ═══════════════════════════════════════ */
+  /* âââââââââââââââââââââââââââââââââââââââ
+     HERO â Warning Banner
+     âââââââââââââââââââââââââââââââââââââââ */
 
   .hero {
     background: var(--blacker);
@@ -140,9 +140,9 @@
     margin-top: 24px;
   }
 
-  /* ═══════════════════════════════════════
+  /* âââââââââââââââââââââââââââââââââââââââ
      BUTTONS
-     ═══════════════════════════════════════ */
+     âââââââââââââââââââââââââââââââââââââââ */
 
   .btn {
     display: inline-block;
@@ -187,9 +187,9 @@
     background: var(--green-dim);
   }
 
-  /* ═══════════════════════════════════════
+  /* âââââââââââââââââââââââââââââââââââââââ
      TERMINAL
-     ═══════════════════════════════════════ */
+     âââââââââââââââââââââââââââââââââââââââ */
 
   .terminal-container {
     max-width: 720px;
@@ -243,9 +243,9 @@
     50% { opacity: 0; }
   }
 
-  /* ═══════════════════════════════════════
+  /* âââââââââââââââââââââââââââââââââââââââ
      CONTENT SECTIONS
-     ═══════════════════════════════════════ */
+     âââââââââââââââââââââââââââââââââââââââ */
 
   .section {
     max-width: 1000px;
@@ -290,9 +290,9 @@
     max-width: 720px;
   }
 
-  /* ═══════════════════════════════════════
+  /* âââââââââââââââââââââââââââââââââââââââ
      PAIN POINTS GRID
-     ═══════════════════════════════════════ */
+     âââââââââââââââââââââââââââââââââââââââ */
 
   .pain-grid {
     display: grid;
@@ -321,9 +321,9 @@
     color: var(--gray);
   }
 
-  /* ═══════════════════════════════════════
+  /* âââââââââââââââââââââââââââââââââââââââ
      PARADIGM MATRIX
-     ═══════════════════════════════════════ */
+     âââââââââââââââââââââââââââââââââââââââ */
 
   .paradigm-matrix {
     display: grid;
@@ -367,18 +367,18 @@
   }
 
   .paradigm-col li::before {
-    content: '▸ ';
+    content: 'â¸ ';
     color: var(--green);
   }
 
   .paradigm-col.sovereign li::before {
-    content: '◆ ';
+    content: 'â ';
     color: var(--orange);
   }
 
-  /* ═══════════════════════════════════════
+  /* âââââââââââââââââââââââââââââââââââââââ
      COMPARISON TABLE
-     ═══════════════════════════════════════ */
+     âââââââââââââââââââââââââââââââââââââââ */
 
   .comparison-table {
     width: 100%;
@@ -427,9 +427,9 @@
     color: var(--orange);
   }
 
-  /* ═══════════════════════════════════════
+  /* âââââââââââââââââââââââââââââââââââââââ
      ARCHITECTURE DIAGRAM (SIMPLIFIED)
-     ═══════════════════════════════════════ */
+     âââââââââââââââââââââââââââââââââââââââ */
 
   .arch-diagram {
     background: var(--blacker);
@@ -444,9 +444,9 @@
     color: var(--white);
   }
 
-  /* ═══════════════════════════════════════
+  /* âââââââââââââââââââââââââââââââââââââââ
      CASE STUDY
-     ═══════════════════════════════════════ */
+     âââââââââââââââââââââââââââââââââââââââ */
 
   .case-study {
     background: var(--dark-gray);
@@ -470,9 +470,9 @@
     margin-top: 16px;
   }
 
-  /* ═══════════════════════════════════════
+  /* âââââââââââââââââââââââââââââââââââââââ
      FEATURE TABLE
-     ═══════════════════════════════════════ */
+     âââââââââââââââââââââââââââââââââââââââ */
 
   .feature-grid {
     display: grid;
@@ -506,9 +506,9 @@
     margin: 0;
   }
 
-  /* ═══════════════════════════════════════
+  /* âââââââââââââââââââââââââââââââââââââââ
      SOCIAL PROOF
-     ═══════════════════════════════════════ */
+     âââââââââââââââââââââââââââââââââââââââ */
 
   .testimonial {
     border-left: 3px solid var(--green);
@@ -533,9 +533,9 @@
     color: var(--orange);
   }
 
-  /* ═══════════════════════════════════════
+  /* âââââââââââââââââââââââââââââââââââââââ
      PRICING / CTA
-     ═══════════════════════════════════════ */
+     âââââââââââââââââââââââââââââââââââââââ */
 
   .pricing-grid {
     display: grid;
@@ -602,18 +602,18 @@
   }
 
   .pricing-tier li::before {
-    content: '✓ ';
+    content: 'â ';
     color: var(--green);
   }
 
   .pricing-tier li.no::before {
-    content: '✗ ';
+    content: 'â ';
     color: var(--red);
   }
 
-  /* ═══════════════════════════════════════
+  /* âââââââââââââââââââââââââââââââââââââââ
      INTEGRATION PARTNERS
-     ═══════════════════════════════════════ */
+     âââââââââââââââââââââââââââââââââââââââ */
 
   .partner-banner {
     background: var(--dark-gray);
@@ -631,9 +631,9 @@
     margin-bottom: 8px;
   }
 
-  /* ═══════════════════════════════════════
+  /* âââââââââââââââââââââââââââââââââââââââ
      FOOTER
-     ═══════════════════════════════════════ */
+     âââââââââââââââââââââââââââââââââââââââ */
 
   footer {
     border-top: 4px solid var(--orange);
@@ -660,9 +660,9 @@
     text-decoration: underline;
   }
 
-  /* ═══════════════════════════════════════
+  /* âââââââââââââââââââââââââââââââââââââââ
      RESPONSIVE
-     ═══════════════════════════════════════ */
+     âââââââââââââââââââââââââââââââââââââââ */
 
   @media (max-width: 768px) {
     .paradigm-matrix {
@@ -698,9 +698,9 @@
 </head>
 <body>
 
-<!-- ═══════════════════════ HERO ═══════════════════════ -->
+<!-- âââââââââââââââââââââââ HERO âââââââââââââââââââââââ -->
 <section class="hero">
-  <span class="hero-badge">⚠ Production Warning</span>
+  <span class="hero-badge">â  Production Warning</span>
 
   <h1>
     YOUR AGENT<br>
@@ -712,24 +712,24 @@
   <div class="hero-stat">
     <span class="number">$106,000</span>
     <span class="label">Reported Loss &mdash; AutoGen #7770</span>
-    <span class="source">AutoGen #7770 — Agent destroyed AWS management account</span>
+    <span class="source">AutoGen #7770 â Agent destroyed AWS management account</span>
   </div>
 
   <p class="hero-subtitle">
     SHACKLE is the 1-line runtime circuit breaker that stops autonomous agents
     from burning your API budget in silent infinite loops. Works with CrewAI,
-    LangGraph, AutoGen — zero refactoring.
+    LangGraph, AutoGen â zero refactoring.
   </p>
 
   <div class="hero-cta">
     <a href="#how-it-works" class="btn btn-primary">
-      See How It Works ↓
+      See How It Works â
     </a>
-    <a href="https://github.com/Fame510/SHACKLE-PRO-" class="btn btn-ghost">
+    <a href="https://github.com/Fame510/SHACKLE" class="btn btn-ghost">
       View Source (AGPLv3)
     </a>
     <a href="#pricing" class="btn btn-ghost">
-      Pricing & Implementation ↓
+      Pricing & Implementation â
     </a>
   </div>
 
@@ -744,55 +744,55 @@
       <div class="terminal-body">
         <span class="term-prompt">$ </span><span class="term-command">python agent_kickoff.py</span><br>
         <span class="term-output">[Agent] Running research task...</span><br>
-        <span class="term-output">[Tool] web_search("latest AI news") → 200 OK</span><br>
-        <span class="term-output">[Tool] web_search("latest AI news") → 401 Unauthorized</span><br>
-        <span class="term-warn">[Tool] web_search("latest AI news") → 401 Unauthorized ⚠</span><br>
+        <span class="term-output">[Tool] web_search("latest AI news") â 200 OK</span><br>
+        <span class="term-output">[Tool] web_search("latest AI news") â 401 Unauthorized</span><br>
+        <span class="term-warn">[Tool] web_search("latest AI news") â 401 Unauthorized â </span><br>
         <br>
-        <span class="term-highlight">⛓️ SHACKLE CIRCUIT BREAKER: REPETITIVE_TOOL_CALL</span><br>
+        <span class="term-highlight">âï¸ SHACKLE CIRCUIT BREAKER: REPETITIVE_TOOL_CALL</span><br>
         <br>
         <span class="term-output">Agent: ResearchAgent</span><br>
         <span class="term-output">Tool: web_search</span><br>
         <span class="term-output">Input: {"query": "latest AI news", "error": "401 Unauthorized"}</span><br>
-        <span class="term-error">Call Count: 3x → CIRCUIT OPEN</span><br>
+        <span class="term-error">Call Count: 3x â CIRCUIT OPEN</span><br>
         <br>
-        <span class="term-output">━━━ Session Stats ━━━</span><br>
+        <span class="term-output">âââ Session Stats âââ</span><br>
         <span class="term-output">Tokens: In: 8,400 | Out: 1,200</span><br>
         <span class="term-output">Session Cost: $0.02850 (saved: ~$400.00)</span><br>
         <span class="term-output">Time Running: 47.2s</span><br>
         <br>
         <span class="term-highlight">[R] Resume/Reset&nbsp;&nbsp;[S] Skip&nbsp;&nbsp;[A] Abort</span><br>
-        <span class="term-cursor">▌</span>
+        <span class="term-cursor">â</span>
       </div>
     </div>
   </div>
 </section>
 
-<!-- ═══════════════════════ THE PROBLEM ═══════════════════════ -->
+<!-- âââââââââââââââââââââââ THE PROBLEM âââââââââââââââââââââââ -->
 <section class="section">
   <span class="section-label">// The Crisis</span>
   <h2>Your Agent Is Bleeding Money. Right Now.</h2>
 
   <div class="pain-grid">
     <div class="pain-card">
-      <h4>🔄 The Loop of Death</h4>
-      <p>Agent hits an error. Retries same tool with same input. Burns tokens quadratically. You wake up to a $400 bill — or worse, a $106,000 AWS disaster — with no idea what happened.</p>
+      <h4>ð The Loop of Death</h4>
+      <p>Agent hits an error. Retries same tool with same input. Burns tokens quadratically. You wake up to a $400 bill â or worse, a $106,000 AWS disaster â with no idea what happened.</p>
     </div>
     <div class="pain-card">
-      <h4>💰 No Native Budget Enforcement</h4>
+      <h4>ð° No Native Budget Enforcement</h4>
       <p>CrewAI, AutoGen, and LangGraph have zero built-in cost guardrails. Your agent runs until it runs out of <em>your</em> money. Framework developers admit this is unsolved.</p>
     </div>
     <div class="pain-card">
-      <h4>⏱️ Hung Tools, Silent Failures</h4>
+      <h4>â±ï¸ Hung Tools, Silent Failures</h4>
       <p>API hangs. Agent waits forever. No timeout. No alert. Just a frozen process burning compute budget. Across 20+ agents in production, this compounds exponentially.</p>
     </div>
     <div class="pain-card">
-      <h4>📊 Cross-Framework Invisible</h4>
+      <h4>ð Cross-Framework Invisible</h4>
       <p>Production stacks run CrewAI + AutoGen + LangGraph simultaneously. Each framework has different failure modes. None has a unified circuit breaker. Until now.</p>
     </div>
   </div>
 </section>
 
-<!-- ═══════════════════════ CASE STUDY ═══════════════════════ -->
+<!-- âââââââââââââââââââââââ CASE STUDY âââââââââââââââââââââââ -->
 <section class="section section-dark">
   <span class="section-label">// Case Study</span>
   <h2>This Actually Happened.</h2>
@@ -804,15 +804,15 @@
       in a recursive cleanup loop. No circuit breaker. No budget guard. No kill switch.
     </p>
     <p style="color:var(--gray);font-size:13px;margin-top:8px;">
-      Source: <a href="https://github.com/microsoft/autogen/issues/7770" style="color:var(--orange);">microsoft/autogen#7770</a> — @tzb1-ai, enterprise infrastructure operator
+      Source: <a href="https://github.com/microsoft/autogen/issues/7770" style="color:var(--orange);">microsoft/autogen#7770</a> â @tzb1-ai, enterprise infrastructure operator
     </p>
     <p class="what-if">
-      SHACKLE's repeat-call + error-cascade breaker is built to trip on exactly this recursive-loop pattern—before it compounds.
+      SHACKLE's repeat-call + error-cascade breaker is built to trip on exactly this recursive-loop patternâbefore it compounds.
     </p>
   </div>
 </section>
 
-<!-- ═══════════════════════ HOW IT WORKS ═══════════════════════ -->
+<!-- âââââââââââââââââââââââ HOW IT WORKS âââââââââââââââââââââââ -->
 <a id="how-it-works"></a>
 <section class="section">
   <span class="section-label">// Solution</span>
@@ -833,8 +833,8 @@
       <br>
       <span style="color:#fff;">safe_kickoff</span>()<br>
       <br>
-      <span class="term-prompt">$ </span><span class="term-command">pip install shackle-guard && python agent.py</span><br>
-      <span class="term-output">✅ SHACKLE active. Guards: budget=$0.25, repeat=3x, timeout=180s</span>
+      <span class="term-prompt">$ </span><span class="term-command">pip install shackle && python agent.py</span><br>
+      <span class="term-output">â SHACKLE active. Guards: budget=$0.25, repeat=3x, timeout=180s</span>
     </div>
   </div>
 
@@ -846,44 +846,44 @@
 
   <div class="feature-grid">
     <div class="feature-item">
-      <div class="icon">🛑</div>
+      <div class="icon">ð</div>
       <h4>Loop of Death Prevention</h4>
       <p>Detects identical sequential tool calls and error cascades. Trips circuit breaker before quadratic token burn.</p>
     </div>
     <div class="feature-item">
-      <div class="icon">💰</div>
+      <div class="icon">ð°</div>
       <h4>Budget Enforcement</h4>
       <p>Real-time token tracking against client-side pricing table. Hard freeze when budget is exhausted.</p>
     </div>
     <div class="feature-item">
-      <div class="icon">⏱️</div>
+      <div class="icon">â±ï¸</div>
       <h4>Execution Timeouts</h4>
       <p>Kills hung threads on dead APIs. No more frozen processes burning compute.</p>
     </div>
     <div class="feature-item">
-      <div class="icon">🖥️</div>
+      <div class="icon">ð¥ï¸</div>
       <h4>HITL Console</h4>
       <p>Interactive terminal with Resume / Skip / Abort. Human stays in the loop when it matters.</p>
     </div>
     <div class="feature-item">
-      <div class="icon">🔒</div>
+      <div class="icon">ð</div>
       <h4>100% Client-Side</h4>
       <p>No telemetry. No phone-home. No hidden SaaS. Your agent data stays on your machine.</p>
     </div>
     <div class="feature-item">
-      <div class="icon">🔀</div>
+      <div class="icon">ð</div>
       <h4>Cross-Framework</h4>
-      <p>CrewAI ✅ LangGraph ✅ AutoGen ✅ Smolagents 🧪 — one decorator, all frameworks.</p>
+      <p>CrewAI â LangGraph â AutoGen â Smolagents ð§ª â one decorator, all frameworks.</p>
     </div>
   </div>
 </section>
 
-<!-- ═══════════════════════ COMPARISON ═══════════════════════ -->
+<!-- âââââââââââââââââââââââ COMPARISON âââââââââââââââââââââââ -->
 <section class="section">
   <span class="section-label">// Why SHACKLE Exists</span>
   <h2>Nothing Else Does This.</h2>
   <p>
-    Every AI agent framework offers <em>some</em> safety mechanism — but none provide a
+    Every AI agent framework offers <em>some</em> safety mechanism â but none provide a
     dedicated pre-execution circuit breaker with mathematically verified decision logic.
     Here's the landscape:
   </p>
@@ -902,73 +902,73 @@
     <tbody>
       <tr>
         <td>Pre-execution interception</td>
-        <td class="cross">✗ In-band</td>
-        <td class="cross">✗ Post-hoc</td>
-        <td class="cross">✗ Observability only</td>
-        <td class="check">✓ Process-level</td>
+        <td class="cross">â In-band</td>
+        <td class="cross">â Post-hoc</td>
+        <td class="cross">â Observability only</td>
+        <td class="check">â Process-level</td>
       </tr>
       <tr>
         <td>Budget enforcement</td>
-        <td class="cross">✗</td>
-        <td class="partial">△ Token count only</td>
-        <td class="cross">✗</td>
-        <td class="check">✓ Per-session USD tracking</td>
+        <td class="cross">â</td>
+        <td class="partial">â³ Token count only</td>
+        <td class="cross">â</td>
+        <td class="check">â Per-session USD tracking</td>
       </tr>
       <tr>
         <td>Loop-of-death detection</td>
-        <td class="cross">✗</td>
-        <td class="partial">△ Recursion limit</td>
-        <td class="partial">△ After-the-fact</td>
-        <td class="check">✓ 3-call repeat + error amplification</td>
+        <td class="cross">â</td>
+        <td class="partial">â³ Recursion limit</td>
+        <td class="partial">â³ After-the-fact</td>
+        <td class="check">â 3-call repeat + error amplification</td>
       </tr>
       <tr>
         <td>HITL (human-in-the-loop)</td>
-        <td class="cross">✗</td>
-        <td class="partial">△ Manual only</td>
-        <td class="cross">✗</td>
-        <td class="check">✓ CLI + WebSocket remote</td>
+        <td class="cross">â</td>
+        <td class="partial">â³ Manual only</td>
+        <td class="cross">â</td>
+        <td class="check">â CLI + WebSocket remote</td>
       </tr>
       <tr>
         <td>Error signal detection</td>
-        <td class="cross">✗</td>
-        <td class="cross">✗</td>
-        <td class="cross">✗</td>
-        <td class="check">✓ 401/403/500/timeout cascade</td>
+        <td class="cross">â</td>
+        <td class="cross">â</td>
+        <td class="cross">â</td>
+        <td class="check">â 401/403/500/timeout cascade</td>
       </tr>
       <tr>
         <td>Mathematical verification</td>
-        <td class="cross">✗</td>
-        <td class="cross">✗</td>
-        <td class="cross">✗</td>
-        <td class="check">✓ 9 invariants (Hypothesis-tested)</td>
+        <td class="cross">â</td>
+        <td class="cross">â</td>
+        <td class="cross">â</td>
+        <td class="check">â 9 invariants (Hypothesis-tested)</td>
       </tr>
       <tr>
         <td>Cryptographic audit trail</td>
-        <td class="cross">✗</td>
-        <td class="cross">✗</td>
-        <td class="cross">✗</td>
-        <td class="check">✓ Ed25519-signed, immutable</td>
+        <td class="cross">â</td>
+        <td class="cross">â</td>
+        <td class="cross">â</td>
+        <td class="check">â Ed25519-signed, immutable</td>
       </tr>
       <tr>
         <td>Framework-agnostic</td>
-        <td class="cross">✗</td>
-        <td class="cross">✗ Framework-locked</td>
-        <td class="partial">△ LangChain only</td>
-        <td class="check">✓ Works with ANY agent</td>
+        <td class="cross">â</td>
+        <td class="cross">â Framework-locked</td>
+        <td class="partial">â³ LangChain only</td>
+        <td class="check">â Works with ANY agent</td>
       </tr>
       <tr>
         <td>Zero-refactor integration</td>
-        <td class="partial">△ System prompt</td>
-        <td class="cross">✗ Requires config</td>
-        <td class="cross">✗ Requires SDK</td>
-        <td class="check">✓ One decorator: @Guard</td>
+        <td class="partial">â³ System prompt</td>
+        <td class="cross">â Requires config</td>
+        <td class="cross">â Requires SDK</td>
+        <td class="check">â One decorator: @Guard</td>
       </tr>
       <tr>
         <td>Open source</td>
-        <td class="partial">△ Varies</td>
-        <td class="check">✓</td>
-        <td class="cross">✗ Proprietary SaaS</td>
-        <td class="check">✓ AGPLv3 + commercial</td>
+        <td class="partial">â³ Varies</td>
+        <td class="check">â</td>
+        <td class="cross">â Proprietary SaaS</td>
+        <td class="check">â AGPLv3 + commercial</td>
       </tr>
     </tbody>
   </table>
@@ -981,76 +981,76 @@
   </p>
 </section>
 
-<!-- ═══════════════════════ ARCHITECTURE ═══════════════════════ -->
+<!-- âââââââââââââââââââââââ ARCHITECTURE âââââââââââââââââââââââ -->
 <section class="section section-dark">
   <span class="section-label">// Architecture</span>
   <h2>Interpreter-Level Interception.</h2>
-  <p>SHACKLE sits between your agent and the runtime — not as middleware, but as a runtime shim.</p>
+  <p>SHACKLE sits between your agent and the runtime â not as middleware, but as a runtime shim.</p>
 
   <div class="arch-diagram">
-┌─────────────────────────────────────────────────────────┐
-│                 SHACKLE RUNTIME ENVELOPE                │
-│                                                         │
-│  ┌──────────┐    ┌──────────┐    ┌──────────┐          │
-│  │ CrewAI   │    │ AutoGen  │    │LangGraph │          │
-│  └────┬─────┘    └────┬─────┘    └────┬─────┘          │
-│       │               │               │                 │
-│       └───────────────┬───────────────┘                 │
-│                       │                                 │
-│              ┌────────▼────────┐                        │
-│              │  SHACKLE GUARD  │  ← litellm hook        │
-│              │  decide(state,  │  ← BaseTool.run hook   │
-│              │  call) → Verdict│  ← Agent.execute_task  │
-│              └────────┬────────┘                        │
-│                       │                                 │
-│          ┌────────────┼────────────┐                    │
-│          │            │            │                    │
-│     ┌────▼───┐  ┌─────▼────┐ ┌────▼─────┐              │
-│     │ ALLOW  │  │  DENY    │ │  HITL    │              │
-│     │ execute│  │ block +  │ │ pause +  │              │
-│     │ tool   │  │ log      │ │ console  │              │
-│     └────────┘  └──────────┘ └──────────┘              │
-│                                                         │
-│  V1 (Local): In-process, memory state, CLI HITL         │
-│  V2 (Sovereign): Sidecar daemon, Redis, Postgres, WSS   │
-└─────────────────────────────────────────────────────────┘
+âââââââââââââââââââââââââââââââââââââââââââââââââââââââââââ
+â                 SHACKLE RUNTIME ENVELOPE                â
+â                                                         â
+â  ââââââââââââ    ââââââââââââ    ââââââââââââ          â
+â  â CrewAI   â    â AutoGen  â    âLangGraph â          â
+â  ââââââ¬ââââââ    ââââââ¬ââââââ    ââââââ¬ââââââ          â
+â       â               â               â                 â
+â       âââââââââââââââââ¬ââââââââââââââââ                 â
+â                       â                                 â
+â              ââââââââââ¼âââââââââ                        â
+â              â  SHACKLE  â  â litellm hook        â
+â              â  decide(state,  â  â BaseTool.run hook   â
+â              â  call) â Verdictâ  â Agent.execute_task  â
+â              ââââââââââ¬âââââââââ                        â
+â                       â                                 â
+â          ââââââââââââââ¼âââââââââââââ                    â
+â          â            â            â                    â
+â     ââââââ¼ââââ  âââââââ¼âââââ ââââââ¼ââââââ              â
+â     â ALLOW  â  â  DENY    â â  HITL    â              â
+â     â executeâ  â block +  â â pause +  â              â
+â     â tool   â  â log      â â console  â              â
+â     ââââââââââ  ââââââââââââ ââââââââââââ              â
+â                                                         â
+â  V1 (Local): In-process, memory state, CLI HITL         â
+â  V2 (Sovereign): Sidecar daemon, Redis, Postgres, WSS   â
+âââââââââââââââââââââââââââââââââââââââââââââââââââââââââââ
   </div>
 </section>
 
-<!-- ═══════════════════════ PARADIGM MATRIX ═══════════════════════ -->
+<!-- âââââââââââââââââââââââ PARADIGM MATRIX âââââââââââââââââââââââ -->
 <section class="section">
   <span class="section-label">// Deployment</span>
   <h2>Two Paradigms. One Protocol.</h2>
 
   <div class="paradigm-matrix">
     <div class="paradigm-col local">
-      <h4>🖥️ LOCAL HITL (V1)</h4>
+      <h4>ð¥ï¸ LOCAL HITL (V1)</h4>
       <ul>
-        <li>In-process decorator — zero infrastructure</li>
+        <li>In-process decorator â zero infrastructure</li>
         <li>Terminal-based HITL console</li>
         <li>Memory-only state (lost on crash)</li>
         <li>Perfect for development & debugging</li>
-        <li>pip install shackle-guard</li>
-        <li>Free — AGPLv3</li>
+        <li>pip install shackle</li>
+        <li>Free â AGPLv3</li>
       </ul>
-      <a href="https://github.com/Fame510/SHACKLE-PRO-" class="btn btn-ghost" style="margin-top:16px;">View on GitHub →</a>
+      <a href="https://github.com/Fame510/SHACKLE" class="btn btn-ghost" style="margin-top:16px;">View on GitHub â</a>
     </div>
     <div class="paradigm-col sovereign">
-      <h4>🏰 ENTERPRISE SOVEREIGN (V2)</h4>
+      <h4>ð° ENTERPRISE SOVEREIGN (V2)</h4>
       <ul>
-        <li>Sidecar daemon — persistent state</li>
+        <li>Sidecar daemon â persistent state</li>
         <li>Web/mobile remote HITL console</li>
-        <li>Redis + Postgres — state survives crashes</li>
+        <li>Redis + Postgres â state survives crashes</li>
         <li>Distributed budget across serverless/K8s</li>
         <li>SOC2 audit logs (cryptographically signed)</li>
         <li>Commercial license available</li>
       </ul>
-      <a href="mailto:docspoc101@gmail.com?subject=SHACKLE%20Enterprise%20Inquiry" class="btn btn-primary" style="margin-top:16px;">Contact for Pricing →</a>
+      <a href="mailto:docspoc101@gmail.com?subject=SHACKLE%20Enterprise%20Inquiry" class="btn btn-primary" style="margin-top:16px;">Contact for Pricing â</a>
     </div>
   </div>
 </section>
 
-<!-- ═══════════════════════ SOCIAL PROOF ═══════════════════════ -->
+<!-- âââââââââââââââââââââââ SOCIAL PROOF âââââââââââââââââââââââ -->
 <section class="section section-dark">
   <span class="section-label">// Testimonials</span>
   <h2>What Developers Say.</h2>
@@ -1061,7 +1061,7 @@
       You get one unified guardrail across your whole topology."
     </p>
     <p class="attribution">
-      — Creator of <strong>TokenCircuit</strong>, competing LangGraph solution
+      â Creator of <strong>TokenCircuit</strong>, competing LangGraph solution
     </p>
   </div>
 
@@ -1070,24 +1070,24 @@
       "The error-amplification logic (catching 401/500s on the 2nd attempt) is incredibly sharp."
     </p>
     <p class="attribution">
-      — Developer on <strong>LangGraph</strong> issue tracker
+      â Developer on <strong>LangGraph</strong> issue tracker
     </p>
   </div>
 
   <div class="partner-banner">
-    <h4>🔗 Seeking Integration Partners</h4>
+    <h4>ð Seeking Integration Partners</h4>
     <p style="color:var(--gray);font-size:13px;">
       Running multi-agent production systems? SHACKLE fills the circuit breaker gap
       in your delegation protocol. We're looking for integration partners with live
       production deployments. Cross-framework, sandbox-compatible, runtime-level.
     </p>
     <a href="mailto:docspoc101@gmail.com?subject=SHACKLE%20Integration%20Partnership" class="btn btn-green" style="margin-top:12px;">
-      Propose Integration →
+      Propose Integration â
     </a>
   </div>
 </section>
 
-<!-- ═══════════════════════ PRICING ═══════════════════════ -->
+<!-- âââââââââââââââââââââââ PRICING âââââââââââââââââââââââ -->
 <a id="pricing"></a>
 <section class="section">
   <span class="section-label">// Pricing</span>
@@ -1107,7 +1107,7 @@
         <li class="no">SOC2 audit logs</li>
         <li class="no">Commercial license</li>
       </ul>
-      <a href="https://github.com/Fame510/SHACKLE-PRO-" class="btn btn-ghost">GitHub →</a>
+      <a href="https://github.com/Fame510/SHACKLE" class="btn btn-ghost">GitHub â</a>
     </div>
 
     <div class="pricing-tier featured">
@@ -1118,10 +1118,10 @@
         <li>Custom SHACKLE configuration</li>
         <li>Integration with your codebase</li>
         <li>Direct engineer access (not support tickets)</li>
-        <li>30-day guarantee — catches a loop or it's free</li>
+        <li>30-day guarantee â catches a loop or it's free</li>
         <li>Same-day response (within 4 hours)</li>
       </ul>
-      <a href="https://buy.stripe.com/6oU28q54DbsXdpV6Hy9sk00" class="btn btn-primary">Book Implementation →</a>
+      <a href="https://buy.stripe.com/6oU28q54DbsXdpV6Hy9sk00" class="btn btn-primary">Book Implementation â</a>
     </div>
 
     <div class="pricing-tier">
@@ -1136,18 +1136,18 @@
         <li>SLA-backed priority support</li>
         <li>On-premise deployment</li>
       </ul>
-      <a href="mailto:docspoc101@gmail.com?subject=SHACKLE%20Enterprise%20Inquiry" class="btn btn-ghost">Contact →</a>
+      <a href="mailto:docspoc101@gmail.com?subject=SHACKLE%20Enterprise%20Inquiry" class="btn btn-ghost">Contact â</a>
     </div>
   </div>
 </section>
 
-<!-- ═══════════════════════ WHO BUILT THIS ═══════════════════════ -->
+<!-- âââââââââââââââââââââââ WHO BUILT THIS âââââââââââââââââââââââ -->
 <section class="section section-dark">
   <span class="section-label">// Provenance</span>
   <h2>Built by Someone Who Ships.</h2>
 
   <p>
-    Dante Bullock — 52-year-old self-taught systems architect, Oakland, California.
+    Dante Bullock â 52-year-old self-taught systems architect, Oakland, California.
     Founder of <strong style="color:var(--white);">Sovereign Logic</strong>.
     No venture capital. No corporate incubator. Just code that works.
   </p>
@@ -1162,16 +1162,16 @@
   </p>
 </section>
 
-<!-- ═══════════════════════ FOOTER ═══════════════════════ -->
+<!-- âââââââââââââââââââââââ FOOTER âââââââââââââââââââââââ -->
 <footer>
-  <p class="who">SHACKLE — Black Box Flight Recorder for the AI Age</p>
+  <p class="who">SHACKLE â Black Box Flight Recorder for the AI Age</p>
   <p>
     Open source under <a href="https://www.gnu.org/licenses/agpl-3.0">AGPLv3</a>.
     Commercial licensing available.
   </p>
   <p style="margin-top:8px;">
-    Copyright © 2026 Dante Bullock, Sovereign Logic.
-  <p style="margin-top:8px;font-size:11px;">Also building: <a href="https://fame510.github.io/SINGULARITY/" style="color:var(--orange);">SINGULARITY</a> — Zero-latency compute fabric for GPU clusters.</p>
+    Copyright Â© 2026 Dante Bullock, Sovereign Logic.
+  <p style="margin-top:8px;font-size:11px;">Also building: <a href="https://fame510.github.io/SINGULARITY/" style="color:var(--orange);">SINGULARITY</a> â Zero-latency compute fabric for GPU clusters.</p>
   </p>
   <p style="margin-top:4px;font-size:10px;color:var(--border);">
     SHACKLE is a best-effort circuit breaker. You remain responsible for monitoring your own API limits and usage.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=61.0.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "shackle-guard"
+name = "shackle"
 version = "0.1.0"
 description = "A lightweight, framework-agnostic runtime circuit breaker for LLM agents."
 readme = "README.md"

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(
-    name="shackle-guard",
+    name="shackle",
     version="0.1.0",
     description="A lightweight, framework-agnostic runtime circuit breaker for LLM agents.",
     long_description=open("README.md").read(),


### PR DESCRIPTION
## Summary

Makes the SHACKLE identity uniform and every install instruction true, so nothing in the repo points to a dead URL or an unpublished package.

**Changes**
- Install: `pip install shackle-guard` -> `pip install shackle` (README, landing page). Source install (`pip install git+https://github.com/Fame510/SHACKLE.git`) remains the works-today path until PyPI release lands.
- PyPI distribution renamed `shackle-guard` -> `shackle` (pyproject.toml, setup.py) so the future PyPI name matches the import package and the docs.
- Dead URLs fixed: all `github.com/Fame510/SHACKLE-PRO-` references (landing page x3, SP-1.0 spec x3) -> `github.com/Fame510/SHACKLE`.
- Name unified: 'SHACKLE GUARD' -> 'SHACKLE' on the landing page.

**Not touched:** the SINGULARITY cross-link (separate live project), source code, licensing, provenance.

## Why
Uniform naming (SHACKLE everywhere), one canonical repo URL, and install commands that actually work - required before pointing external maintainers at the repo.

## Follow-up
Publish the `shackle` distribution to PyPI, after which `pip install shackle` becomes fully live.