### PR TITLE
Harden concurrent budget accounting + keep SP/1.0 conformance consistent

### DIFF
--- a/fixtures/conformance.json
+++ b/fixtures/conformance.json
@@ -400,6 +400,31 @@
           25
         ]
       }
+    },
+    {
+      "name": "concurrent_budget_overrun",
+      "config": {
+        "budget_usd": 1
+      },
+      "state": {
+        "budget_initial_usd": 1,
+        "budget_remaining_usd": 0.10,
+        "circuit_tripped": false,
+        "seen_nonces": []
+      },
+      "call": {
+        "tool_name": "purchase",
+        "params": {
+          "amount_usd": 5,
+          "tool": "purchase"
+        },
+        "estimated_cost_usd": 0.15,
+        "nonce": 30
+      },
+      "canonical_hash": "c97a9cc83605d95347fb7766e9e605295c980f16ba19d860e4395c5dde312227",
+      "expected_verdict": "DENY",
+      "expected_reason": "budget_overrun",
+      "conformance_note": "CONCURRENCY CONTRACT: a single call whose estimated cost exceeds the PRE-call remaining budget MUST be denied with budget_overrun, even when remaining > 0 (i.e. the budget is not yet exhausted, but this call would push it negative). This is the spec-level guarantee that prevents the runtime from drifting past budget under concurrent calls: implementations MUST consult decide() with the pre-call remaining and the call's estimated_cost_usd, and honor the DENY verdict BEFORE mutating state. Without this check, a runtime that only verifies `total_cost >= budget` after a racy read-modify-write can silently let combined spend exceed the limit. Companion runtime test: tests/test_core.py::TestTriggerEngineLLM::test_concurrent_budget_no_overrun."
     }
   ],
   "transition_contract": {

--- a/shackle/conformance.py
+++ b/shackle/conformance.py
@@ -50,6 +50,7 @@ def decide(
          (specialized: duplicate resume vs terminal    -> DENY)
       4. HITL transition contract (pending_transition) -> ALLOW/DENY/HITL
       5. budget exhausted                              -> DENY
+      5b. budget overrun (this call would push remaining negative) -> DENY
       6. max repeat exceeded                           -> DENY
       7. HITL mode 'always'                            -> HITL
       8. HITL budget threshold                         -> HITL
@@ -100,6 +101,21 @@ def decide(
     remaining = state.get("budget_remaining_usd")
     if remaining is not None and remaining <= 0 and budget > 0:
         return ("DENY", "budget_exhausted")
+
+    # 5b. budget overrun: this single call's estimated cost would push
+    # remaining negative. Distinct from budget_exhausted: there is budget
+    # left, but not enough for this call. This is the contract that pins
+    # "fail closed under concurrency" -- if two threads each see remaining
+    # > 0 and each try a call whose cost > remaining, the first to land
+    # must NOT silently drain the budget past zero on the second. The
+    # runtime MUST consult decide() with the pre-call remaining and the
+    # call's estimated_cost_usd so this check fires BEFORE mutation.
+    estimated = call.get("estimated_cost_usd", 0) or 0
+    if (remaining is not None
+            and budget > 0
+            and estimated > 0
+            and (remaining - estimated) < 0):
+        return ("DENY", "budget_overrun")
 
     # 6. max repeat exceeded
     max_repeat = config.get("max_repeat_calls")

--- a/shackle/core.py
+++ b/shackle/core.py
@@ -14,6 +14,7 @@ import asyncio
 import json
 import sys
 import time
+import threading
 import logging
 from typing import Any, Callable, Dict, List, Optional, Tuple
 from dataclasses import dataclass, field
@@ -65,6 +66,16 @@ class ExecutionState:
     total_tool_calls: int = 0
     tool_history: Dict[Tuple[str, str], int] = field(default_factory=dict)
     last_decision: Tuple[str, str] = ("ALLOW", "within_thresholds")  # SP/1.0 decide() verdict
+    # Per-state RLock guards every read-modify-write of the fields above.
+    # The previous design mutated total_cost, input_tokens, output_tokens,
+    # total_tool_calls, and tool_history without any synchronization, so
+    # two threads could each read the same pre-mutation value, both write
+    # their delta, and both pass the post-mutation budget/repeat check
+    # (classic lost-update). RLock (not Lock) because a single thread may
+    # legitimately re-enter: e.g. an LLM call patched by shackle triggering
+    # another LLM call on the same Guard's state. Each Guard scope gets its
+    # own state, so distinct Guard instances never contend.
+    _lock: "threading.RLock" = field(default_factory=threading.RLock)
 
 
 class ShackleInterrupt(Exception):
@@ -146,67 +157,132 @@ class TriggerEngine:
             return ("ALLOW", "decide_unavailable")
 
     def evaluate_llm_call(self, model: str, input_tokens: int, output_tokens: int, state: ExecutionState) -> None:
-        pricing = MODEL_PRICING.get(model.lower(), MODEL_PRICING["default"])
-        call_cost = ((input_tokens * pricing["input"]) + (output_tokens * pricing["output"])) / 1_000_000
-        state.total_cost += call_cost
-        state.input_tokens += input_tokens
-        state.output_tokens += output_tokens
-        # SP/1.0: record the reference decision for this cost state.
-        _remaining = max(self.budget - state.total_cost, 0.0)
-        try:
-            state.last_decision = _sp_decide(
-                {"budget_usd": self.budget},
-                {"budget_remaining_usd": _remaining, "budget_initial_usd": self.budget},
-                {"tool_name": model, "params": {}},
-            )
-        except Exception:  # pragma: no cover
-            pass
-        if state.total_cost >= self.budget:
-            raise ShackleInterrupt(
-                message=f"Budget breached: ${state.total_cost:.5f} spent (limit: ${self.budget:.2f})",
-                trigger_type="BUDGET_EXCEEDED", state=state,
-                details={"model": model, "current_cost": state.total_cost, "limit": self.budget,
-                          "input_tokens": state.input_tokens, "output_tokens": state.output_tokens})
+        # CRITICAL SECTION: the entire read-decide-mutate-check sequence runs
+        # under the per-state RLock. Without this, two concurrent LLM calls
+        # on the same Guard would each read pre-mutation total_cost, each
+        # write their delta, and each pass the post-mutation `>= self.budget`
+        # check (lost update), letting combined spend exceed budget by up to
+        # N*(single-call-cost) before anything trips.
+        with state._lock:
+            pricing = MODEL_PRICING.get(model.lower(), MODEL_PRICING["default"])
+            call_cost = ((input_tokens * pricing["input"]) + (output_tokens * pricing["output"])) / 1_000_000
+            # SP/1.0: consult the reference decision function with the
+            # PRE-mutation remaining + this call's estimated_cost. decide()
+            # returns DENY/budget_overrun if this single call would push
+            # remaining negative, which is the case the previous design
+            # could not catch under concurrency even after locking (the
+            # post-mutation check only fires when we've ALREADY gone over).
+            pre_remaining = max(self.budget - state.total_cost, 0.0)
+            config = {"budget_usd": self.budget}
+            decide_state = {
+                "budget_initial_usd": self.budget,
+                "budget_remaining_usd": pre_remaining,
+                "circuit_tripped": False,
+                "seen_nonces": [],
+            }
+            call = {
+                "tool_name": model,
+                "params": {},
+                "estimated_cost_usd": call_cost,
+            }
+            # decide() is total under the conformance suite, but the previous
+            # implementation silently swallowed any exception with `pass`,
+            # which is the exact opposite of "fail closed". Surface the
+            # failure on the audit trail and deny the call.
+            try:
+                state.last_decision = _sp_decide(config, decide_state, call)
+            except Exception as e:  # pragma: no cover - defensive
+                logger.warning(
+                    "SHACKLE: decide() raised during cost consultation (%r); "
+                    "failing closed (denying call).", e,
+                )
+                state.last_decision = ("DENY", "decide_unavailable_fail_closed")
+            verdict, reason = state.last_decision
+            if verdict == "DENY":
+                if reason == "budget_overrun":
+                    # This single call would exceed the remaining budget.
+                    # Do NOT mutate state -- the call never happened.
+                    raise ShackleInterrupt(
+                        message=(f"Budget overrun: this call costs ${call_cost:.5f} "
+                                 f"but only ${pre_remaining:.5f} remains "
+                                 f"(limit: ${self.budget:.2f})"),
+                        trigger_type="BUDGET_OVERRUN", state=state,
+                        details={"model": model, "call_cost": call_cost,
+                                 "remaining": pre_remaining, "limit": self.budget})
+                if reason == "budget_exhausted":
+                    # No budget left at all; refuse the call without mutating.
+                    raise ShackleInterrupt(
+                        message=(f"Budget exhausted: ${state.total_cost:.5f} spent "
+                                 f"(limit: ${self.budget:.2f})"),
+                        trigger_type="BUDGET_EXCEEDED", state=state,
+                        details={"model": model, "current_cost": state.total_cost,
+                                 "limit": self.budget})
+                # Any other DENY from decide() is unexpected on the cost
+                # path; fail closed.
+                raise ShackleInterrupt(
+                    message=f"SHACKLE denied call: {reason}",
+                    trigger_type="DECIDE_DENY", state=state,
+                    details={"model": model, "reason": reason,
+                             "call_cost": call_cost, "limit": self.budget})
+            # Allowed by decide(): mutate state, then re-check the
+            # post-mutation total against the hard limit. This catches the
+            # "this call exactly exhausted the budget" edge case (remaining
+            # went from >0 to 0, which is not an overrun, but the call did
+            # spend the last dollar and should not be silently allowed).
+            state.total_cost += call_cost
+            state.input_tokens += input_tokens
+            state.output_tokens += output_tokens
+            if state.total_cost >= self.budget:
+                raise ShackleInterrupt(
+                    message=f"Budget breached: ${state.total_cost:.5f} spent (limit: ${self.budget:.2f})",
+                    trigger_type="BUDGET_EXCEEDED", state=state,
+                    details={"model": model, "current_cost": state.total_cost, "limit": self.budget,
+                              "input_tokens": state.input_tokens, "output_tokens": state.output_tokens})
 
     def evaluate_tool_call(self, agent_name: str, tool_name: str, tool_input: Any, state: ExecutionState) -> None:
-        elapsed = time.time() - state.start_time
-        state.total_tool_calls += 1
+        # CRITICAL SECTION: total_tool_calls, tool_history[key] = get + 1,
+        # and last_decision are all racy under concurrent tool invocations
+        # (e.g. a thread-pool executor inside the agent framework dispatching
+        # multiple tools in parallel). Same lock as the cost path.
+        with state._lock:
+            elapsed = time.time() - state.start_time
+            state.total_tool_calls += 1
 
-        if elapsed > self.timeout_seconds:
-            raise ShackleInterrupt(
-                message=f"Execution timeout: {elapsed:.1f}s elapsed (limit: {self.timeout_seconds}s)",
-                trigger_type="TIMEOUT_REACHED", state=state,
-                details={"elapsed_seconds": elapsed, "limit": self.timeout_seconds})
+            if elapsed > self.timeout_seconds:
+                raise ShackleInterrupt(
+                    message=f"Execution timeout: {elapsed:.1f}s elapsed (limit: {self.timeout_seconds}s)",
+                    trigger_type="TIMEOUT_REACHED", state=state,
+                    details={"elapsed_seconds": elapsed, "limit": self.timeout_seconds})
 
-        input_key = _canonicalize_tool_input(tool_input)  # FIX #1
-        key = (tool_name, input_key)
-        state.tool_history[key] = state.tool_history.get(key, 0) + 1
-        count = state.tool_history[key]
+            input_key = _canonicalize_tool_input(tool_input)  # FIX #1
+            key = (tool_name, input_key)
+            state.tool_history[key] = state.tool_history.get(key, 0) + 1
+            count = state.tool_history[key]
 
-        input_lower = input_key.lower()
-        is_error_loop = any(token in input_lower for token in
-                             ("error", "failed", "unauthorized", "401", "403", "500", "timeout"))
-        effective_count = count + (1 if is_error_loop and count >= 2 else 0)
+            input_lower = input_key.lower()
+            is_error_loop = any(token in input_lower for token in
+                                 ("error", "failed", "unauthorized", "401", "403", "500", "timeout"))
+            effective_count = count + (1 if is_error_loop and count >= 2 else 0)
 
-        # ---- SP/1.0: consult the reference decision function ----
-        # Map live runtime state onto decide()'s (config, state, call) contract and
-        # record its verdict. This makes core.py literally exercise the same decision
-        # surface the conformance fixtures verify, on every tool call.
-        sp_verdict, sp_reason = self._consult_decide(tool_name, effective_count, state)
-        state.last_decision = (sp_verdict, sp_reason)
+            # ---- SP/1.0: consult the reference decision function ----
+            # Map live runtime state onto decide()'s (config, state, call) contract and
+            # record its verdict. This makes core.py literally exercise the same decision
+            # surface the conformance fixtures verify, on every tool call.
+            sp_verdict, sp_reason = self._consult_decide(tool_name, effective_count, state)
+            state.last_decision = (sp_verdict, sp_reason)
 
-        if effective_count >= self.max_repeat_calls:
-            raise ShackleInterrupt(
-                message=f"Loop of Death detected: '{tool_name}' called {count}x with identical input",
-                trigger_type="REPETITIVE_TOOL_CALL", state=state,
-                details={"agent": agent_name, "tool": tool_name, "input": input_key[:200],
-                          "call_count": count, "error_loop": is_error_loop})
+            if effective_count >= self.max_repeat_calls:
+                raise ShackleInterrupt(
+                    message=f"Loop of Death detected: '{tool_name}' called {count}x with identical input",
+                    trigger_type="REPETITIVE_TOOL_CALL", state=state,
+                    details={"agent": agent_name, "tool": tool_name, "input": input_key[:200],
+                              "call_count": count, "error_loop": is_error_loop})
 
-        if state.total_tool_calls >= self.max_tool_calls:
-            raise ShackleInterrupt(
-                message=f"Max tool calls reached: {state.total_tool_calls} (limit: {self.max_tool_calls})",
-                trigger_type="MAX_TOOL_CALLS", state=state,
-                details={"total_calls": state.total_tool_calls, "limit": self.max_tool_calls})
+            if state.total_tool_calls >= self.max_tool_calls:
+                raise ShackleInterrupt(
+                    message=f"Max tool calls reached: {state.total_tool_calls} (limit: {self.max_tool_calls})",
+                    trigger_type="MAX_TOOL_CALLS", state=state,
+                    details={"total_calls": state.total_tool_calls, "limit": self.max_tool_calls})
 
 
 def render_hitl_terminal(interrupt: ShackleInterrupt) -> str:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -57,7 +57,91 @@ class TestTriggerEngineLLM:
         state = ExecutionState()
         with pytest.raises(ShackleInterrupt) as exc:
             engine.evaluate_llm_call("gpt-4o", 100_000, 100_000, state)
+        # call cost (1.25) > remaining (0.0001) -- this is an OVERRUN
+        # (a call that would push us over), not an EXCEEDED (we already
+        # went over). decide() must catch it BEFORE state is mutated.
+        assert exc.value.trigger_type == "BUDGET_OVERRUN"
+        # And the state must NOT have been mutated by the denied call.
+        assert state.total_cost == 0.0
+        assert state.input_tokens == 0
+        assert state.output_tokens == 0
+
+    def test_budget_exhausted_raises(self):
+        """When remaining is already 0 (a prior call spent the last dollar),
+        any further call is denied with BUDGET_EXCEEDED, not BUDGET_OVERRUN."""
+        engine = TriggerEngine(budget=0.20)
+        state = ExecutionState()
+        # Pre-populate state as if a prior call already exhausted the budget.
+        state.total_cost = 0.20
+        with pytest.raises(ShackleInterrupt) as exc:
+            engine.evaluate_llm_call("gpt-4o", 1_000, 1_000, state)
         assert exc.value.trigger_type == "BUDGET_EXCEEDED"
+
+    def test_budget_exact_hit_raises(self):
+        """A call that exactly exhausts the budget (remaining - cost == 0)
+        is ALLOWED by decide() (not an overrun) but trips the post-mutation
+        hard limit, raising BUDGET_EXCEEDED."""
+        engine = TriggerEngine(budget=0.20)
+        state = ExecutionState()
+        # gpt-4o-mini: $0.15/1M in, $0.60/1M out. 25,000 output tokens
+        # at $0.60/1M = $0.015 EXACTLY in floating point. Pre-charge state
+        # to $0.185 so pre_remaining = $0.015 exactly, and the call lands
+        # precisely on $0.20 total (not above, not below).
+        state.total_cost = 0.185
+        with pytest.raises(ShackleInterrupt) as exc:
+            engine.evaluate_llm_call("gpt-4o-mini", 0, 25_000, state)
+        assert exc.value.trigger_type == "BUDGET_EXCEEDED"
+
+    def test_concurrent_budget_no_overrun(self):
+        """Concurrent LLM calls must not allow the budget to be exceeded
+        due to lost updates in the read-modify-write of total_cost.
+
+        This is the runtime counterpart to the conformance fixture
+        ``concurrent_budget_overrun``. Without the per-state RLock around
+        the read-decide-mutate-check critical section, this test is flaky
+        and total_cost can exceed budget.
+        """
+        import threading
+        engine = TriggerEngine(budget=0.20)
+        state = ExecutionState()
+        # Each call costs $0.05 at gpt-4o pricing: 4000 in + 4000 out
+        # -> (4000*2.50 + 4000*10.00)/1M = 0.05 exactly.
+        N_THREADS = 20
+        results: list = []
+        barrier = threading.Barrier(N_THREADS)
+
+        def worker():
+            barrier.wait()  # release all threads simultaneously
+            try:
+                engine.evaluate_llm_call("gpt-4o", 4_000, 4_000, state)
+                results.append(("ok", None))
+            except ShackleInterrupt as e:
+                results.append(("deny", e.trigger_type))
+
+        threads = [threading.Thread(target=worker) for _ in range(N_THREADS)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        # Invariant 1: total cost must never exceed budget.
+        assert state.total_cost <= engine.budget + 1e-9, (
+            f"Budget overrun: total_cost={state.total_cost} > budget={engine.budget}"
+        )
+        # Invariant 2: at most 4 calls (4 * 0.05 = 0.20 = budget) succeeded.
+        ok = [r for r in results if r[0] == "ok"]
+        assert len(ok) <= 4, f"Too many successful calls under contention: {len(ok)}"
+        # Invariant 3: state total_cost must equal (successful calls) * 0.05,
+        # i.e. no lost updates: the counter must be the EXACT sum of
+        # individual call_costs, not a clobbered-over write.
+        assert abs(state.total_cost - len(ok) * 0.05) < 1e-9, (
+            f"Lost update: total_cost={state.total_cost} != {len(ok) * 0.05}"
+        )
+        # Invariant 4: every denial must be a budget-family trigger.
+        for status, trig in (r for r in results if r[0] == "deny"):
+            assert trig in ("BUDGET_EXCEEDED", "BUDGET_OVERRUN"), (
+                f"Unexpected denial trigger under concurrent budget contention: {trig}"
+            )
 
     def test_unknown_model_uses_default_pricing(self):
         engine = TriggerEngine(budget=1.00)

--- a/tests/test_litellm_guardrail.py
+++ b/tests/test_litellm_guardrail.py
@@ -94,8 +94,12 @@ def test_b_budget_exceeded_on_record():
     g = ShackleEngineGuardrail(budget=0.0001, max_repeat_calls=99, timeout_seconds=1000)
     g.check(_req(content="spend"))
     with pytest.raises(ShackleBlocked) as e:
-        g.record(_req(), _usage(1000000, 1000000))  # huge spend -> BUDGET_EXCEEDED
-    assert e.value.reason == "BUDGET_EXCEEDED"
+        g.record(_req(), _usage(1000000, 1000000))  # huge spend -> BUDGET_OVERRUN
+    # call cost (12.50) vastly exceeds the budget (0.0001), so decide()
+    # catches it as a BUDGET_OVERRUN (the call would push remaining
+    # negative) BEFORE any state is mutated -- strictly better than the
+    # pre-fix behavior which would have mutated then raised BUDGET_EXCEEDED.
+    assert e.value.reason == "BUDGET_OVERRUN"
 
 
 def test_b_distinct_calls_do_not_trip():

--- a/v2/daemon/audit.py
+++ b/v2/daemon/audit.py
@@ -7,7 +7,7 @@ import base64
 import json
 import logging
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Dict, Optional
 
@@ -203,7 +203,7 @@ class AuditLogger:
     ):
         """Log a pre-execution decision"""
         try:
-            timestamp = datetime.utcnow()
+            timestamp = datetime.now(timezone.utc)
             
             record = {
                 "timestamp": timestamp.isoformat(),
@@ -244,7 +244,7 @@ class AuditLogger:
     ):
         """Log a post-execution result"""
         try:
-            timestamp = datetime.utcnow()
+            timestamp = datetime.now(timezone.utc)
             
             record = {
                 "timestamp": timestamp.isoformat(),

--- a/v2/spec/decide.py
+++ b/v2/spec/decide.py
@@ -41,6 +41,7 @@ class Verdict(Enum):
 class DenyReason(Enum):
     UNSPECIFIED = "unspecified"
     BUDGET_EXHAUSTED = "budget_exhausted"
+    BUDGET_OVERRUN = "budget_overrun"
     MAX_REPEAT_EXCEEDED = "max_repeat_exceeded"
     CIRCUIT_OPEN = "circuit_open"
     WINDOW_EXCEEDED = "window_exceeded"
@@ -284,7 +285,12 @@ def decide(
             if config.hitl_mode in (HitlMode.ON_DENY, HitlMode.ALWAYS):
                 return Decision(Verdict.HITL,
                                 human_readable=f"Cost ${call.estimated_cost_usd:.4f} > remaining ${state.budget_remaining_usd:.4f}")
-            return Decision(Verdict.DENY, DenyReason.BUDGET_EXHAUSTED,
+            # remaining is > 0 here (the <=0 case returned budget_exhausted
+            # above), so a call whose estimated cost exceeds remaining is an
+            # OVERRUN, not exhaustion. Distinct reason keeps this consistent
+            # with shackle/conformance.py and the concurrent_budget_overrun
+            # fixture (fail closed BEFORE the budget is driven negative).
+            return Decision(Verdict.DENY, DenyReason.BUDGET_OVERRUN,
                             f"Cost ${call.estimated_cost_usd:.4f} > remaining ${state.budget_remaining_usd:.4f}")
 
     # Layer 4: Repeat call guard


### PR DESCRIPTION
## Summary
Three fixes, all with tests, CI-green locally.

### 1. Concurrency-safe budget accounting (`shackle/core.py`)
Wraps the `ExecutionState` cost read → decide → update → check sequence under a
per-state `RLock` in both `evaluate_llm_call` and `evaluate_tool_call`, and makes
the `decide()` path fail closed rather than swallowing errors. This makes budget
enforcement correct under concurrent calls.

### 2. SP/1.0 conformance consistency
Adds a `budget_overrun` decide() reason (precedence 5b) and a
`concurrent_budget_overrun` fixture, implemented in **both** reference
implementations (`shackle/conformance.py` and `v2/spec/decide.py`) so the shared
fixtures conform across both. Note: this extends the SP/1.0 normative surface
with a new deny reason — a deliberate spec addition.

### 3. Timezone hygiene (`v2/daemon/audit.py`)
`datetime.utcnow()` → `datetime.now(timezone.utc)` at both audit call sites.

## Tests
- `tests/` — 37 passed (adds budget overrun/exhausted/exact-hit + a concurrency
  regression guard).
- v2 conformance — 27 passed; standalone harness verifies all fixtures.
