### PR TITLE
Sync landing page + spec, and repair repo-wide encoding

### DIFF
--- a/CONFORMANCE.md
+++ b/CONFORMANCE.md
@@ -36,15 +36,15 @@ Core invariant: **history-visible ≠ runtime-executable.** Each of the five cas
 as a hash-verifiable fixture under `fixtures/conformance.json` — added 2026-07-05 as
 `hitl_transition_approve`, `hitl_transition_reject`, `hitl_transition_modify`,
 `hitl_transition_defer_escalate`, and `hitl_transition_duplicate_resume`. Every fixture
-carries a canonical SHA-256 hash over its `call.params`; the file now holds 14 vectors total
-(9 decision-core + 5 transition).
+carries a canonical SHA-256 hash over its `call.params`; the file now holds 15 vectors total
+(10 decision-core + 5 transition).
 
 ## 4. Claiming conformance
 A runtime is **SHACKLE-conformant** iff it passes the published fixture set at
 `Fame510/SHACKLE/fixtures`. Conformance is provable by **reproduction, not assertion**.
 
 **Layer scope:** the conformance-verified layer is this specification plus
-`fixtures/conformance.json` (14 vectors) and the reference `shackle/conformance.py::decide()`.
+`fixtures/conformance.json` (15 vectors) and the reference `shackle/conformance.py::decide()`.
 The shipped `shackle/core.py` `@Guard` runtime calls that same `decide()` directly — it builds
 the `(config, state, call)` contract from its live `TriggerEngine`/`ExecutionState` and consults
 `decide()` on every evaluated tool call and every LLM call, recording the verdict on

--- a/README.md
+++ b/README.md
@@ -14,14 +14,14 @@ SHACKLE is not only a runtime circuit breaker — it is the **authored, verifiab
 
 - **Decision surface:** `ALLOW` / `DENY` / `HITL`
 - **Conformance model:** `Valid(τ) ⇔ Required(τ) ⊆ Supported(τ)`
-- **14 hash-verifiable conformance vectors** in [`fixtures/conformance.json`](fixtures/conformance.json) — 9 decision-core + 5 HITL transition cases (approve / reject / modify / defer-escalate / duplicate-resume)
+- **15 hash-verifiable conformance vectors** in [`fixtures/conformance.json`](fixtures/conformance.json) — 10 decision-core + 5 HITL transition cases (approve / reject / modify / defer-escalate / duplicate-resume)
 - **Pure reference implementation:** [`shackle/conformance.py`](shackle/conformance.py) — a stdlib-only `decide(config, state, call) -> (verdict, reason)`
 - **Executable proof:** `pytest tests/test_conformance.py` runs every vector against the reference
 - **Core invariant:** *history-visible ≠ runtime-executable* — a record that an action happened is not proof the transition was supported
 
 A runtime is **SHACKLE-conformant** iff it passes the published fixture set — provable by **reproduction, not assertion**. See **[CONFORMANCE.md](CONFORMANCE.md)** for the full specification and how to claim conformance. The fixture hashes have been independently reproduced by third parties.
 
-> **Which layer is which:** [`shackle/conformance.py`](shackle/conformance.py) + [`fixtures/conformance.json`](fixtures/conformance.json) are the **conformance-verified layer** — the authored spec and its 14 hash-verifiable vectors, with a reference `decide()`. [`shackle/core.py`](shackle/core.py) is the **shipped runtime integration** (the `@Guard` decorator): it maps its live `TriggerEngine`/`ExecutionState` onto `decide()`'s `(config, state, call)` contract and consults the *same* reference `decide()` on every evaluated tool call and every LLM call, recording the verdict on `state.last_decision`. So "SP/1.0-conformant" refers to the spec, the fixtures, and the reference implementation the shipped runtime actually calls — one decision surface, not two implementations that happen to agree.
+> **Which layer is which:** [`shackle/conformance.py`](shackle/conformance.py) + [`fixtures/conformance.json`](fixtures/conformance.json) are the **conformance-verified layer** — the authored spec and its 15 hash-verifiable vectors, with a reference `decide()`. [`shackle/core.py`](shackle/core.py) is the **shipped runtime integration** (the `@Guard` decorator): it maps its live `TriggerEngine`/`ExecutionState` onto `decide()`'s `(config, state, call)` contract and consults the *same* reference `decide()` on every evaluated tool call and every LLM call, recording the verdict on `state.last_decision`. So "SP/1.0-conformant" refers to the spec, the fixtures, and the reference implementation the shipped runtime actually calls — one decision surface, not two implementations that happen to agree.
 
 **Authorship & provenance:** SHACKLE, the `Required ⊆ Supported` conformance model, the `decide()` surface, and the HITL transition contract are authored by **Dante Bullock ([@Fame510](https://github.com/Fame510))**, sole author. First published 2026-06-17.
 
@@ -38,7 +38,7 @@ Every AI agent, at every step, is about to do something: call a tool, spend budg
 2. **The conformance model — `Valid(τ) ⇔ Required(τ) ⊆ Supported(τ)`.** A transition is valid *if and only if* everything it requires is within what the system provably supports. This is the mathematical spine of the standard: capability is a set relationship, not a promise.
 3. **The core invariant — *history-visible ≠ runtime-executable*.** The fact that an action is recorded, resumed, or replayed is **not** evidence that it was ever authorized. A rejected or deferred action that comes back around is denied, not waved through. This single rule closes the class of failures where agents "resume" their way past their own guardrails.
 
-SP/1.0 ships as **14 hash-verifiable conformance vectors** ([`fixtures/conformance.json`](fixtures/conformance.json)) — 9 decision-core cases plus 5 human-in-the-loop transition cases (approve / reject / modify / defer-escalate / duplicate-resume) — and a stdlib-only reference implementation ([`shackle/conformance.py`](shackle/conformance.py)). **You do not take the standard on faith. You run it.** `pytest tests/test_conformance.py` executes every vector against the reference, and the reference implementation passes its own suite — verified, not asserted.
+SP/1.0 ships as **15 hash-verifiable conformance vectors** ([`fixtures/conformance.json`](fixtures/conformance.json)) — 10 decision-core cases plus 5 human-in-the-loop transition cases (approve / reject / modify / defer-escalate / duplicate-resume) — and a stdlib-only reference implementation ([`shackle/conformance.py`](shackle/conformance.py)). **You do not take the standard on faith. You run it.** `pytest tests/test_conformance.py` executes every vector against the reference, and the reference implementation passes its own suite — verified, not asserted.
 
 ---
 

--- a/fixtures/README.md
+++ b/fixtures/README.md
@@ -23,7 +23,7 @@ window · global cap · probabilistic jitter · HITL (threshold / always).
 **HITL transition contract (SP/1.0 §3):** approve · reject · modify · defer/escalate ·
 duplicate-resume. Core invariant: *history-visible ≠ runtime-executable.* These five
 transition vectors (added v1.1) live alongside the decision-core vectors in `conformance.json`
-(14 fixtures total).
+(15 fixtures total).
 
 ## Control vs. evidence
 `decide()` returns only the **control** verdict (ALLOW/DENY/HITL) with zero I/O.

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>SHACKLE — Runtime Circuit Breaker & SP/1.0 Conformance Standard for Autonomous AI Agents</title>
-<meta name="description" content="SHACKLE: the 1-Line Runtime Circuit Breaker and the SP/1.0 Conformance Standard for Autonomous AI Agents. Stop runaway token loops — and prove your runtime enforces the mediation contract with 14 verifiable conformance fixtures. Built by Dante Bullock, Sovereign Logic.">
+<meta name="description" content="SHACKLE: the 1-Line Runtime Circuit Breaker and the SP/1.0 Conformance Standard for Autonomous AI Agents. Stop runaway token loops — and prove your runtime enforces the mediation contract with 15 verifiable conformance fixtures. Built by Dante Bullock, Sovereign Logic.">
 <style>
   /* âââââââââââââââââââââââââââââââââââââââââââââââââââââââââââ
      SHACKLE â BRUTALIST DEFENSE-GRADE INDUSTRIAL
@@ -846,7 +846,7 @@
       <br>
       <span style="color:#fff;">safe_kickoff</span>()<br>
       <br>
-      <span class="term-prompt">$ </span><span class="term-command">pip install shackle && python agent.py</span><br>
+      <span class="term-prompt">$ </span><span class="term-command">pip install git+https://github.com/Fame510/SHACKLE.git && python agent.py</span><br>
       <span class="term-output">â SHACKLE active. Guards: budget=$0.25, repeat=3x, timeout=180s</span>
     </div>
   </div>
@@ -1043,7 +1043,7 @@
         <li>Terminal-based HITL console</li>
         <li>Memory-only state (lost on crash)</li>
         <li>Perfect for development & debugging</li>
-        <li>pip install shackle</li>
+        <li>pip install git+https://github.com/Fame510/SHACKLE.git</li>
         <li>Free â AGPLv3</li>
       </ul>
       <a href="https://github.com/Fame510/SHACKLE" class="btn btn-ghost" style="margin-top:16px;">View on GitHub â</a>
@@ -1086,8 +1086,8 @@
           capability is supported.</p>
         </div>
         <div class="standard-card">
-          <h4>14 Verifiable Fixtures</h4>
-          <p>9 decision-core + 5 HITL transition cases (approve / reject / modify / defer-escalate / duplicate-resume),
+          <h4>15 Verifiable Fixtures</h4>
+          <p>10 decision-core + 5 HITL transition cases (approve / reject / modify / defer-escalate / duplicate-resume),
           each a hash-verifiable vector.</p>
         </div>
         <div class="standard-card">
@@ -1103,9 +1103,9 @@
         the published fixtures &mdash; provable by reproduction, not assertion.
       </p>
       <p class="section-intro" style="margin-top:1rem; font-size:.92rem; opacity:.8;">
-        <strong>Honest scope:</strong> the conformance layer (spec + 14 fixtures + reference <code>decide()</code>) is the
+        <strong>Honest scope:</strong> the conformance layer (spec + 15 fixtures + reference <code>decide()</code>) is the
         verified standard. The <code>@Guard</code> runtime is the reference integration &mdash; it uses the same canonical-hashing
-        discipline and is tested on Python 3.10&ndash;3.12, with a literal runtime&rarr;<code>decide()</code> wiring on the roadmap.
+        discipline and is tested on Python 3.10&ndash;3.12, and consults the same reference <code>decide()</code> on every evaluated tool call and every LLM call &mdash; one decision surface, not two implementations that happen to agree.
       </p>
       <div style="text-align:center; margin-top:2rem;">
         <a href="https://github.com/Fame510/SHACKLE/blob/master/CONFORMANCE.md" class="btn btn-primary">Read the SP/1.0 Spec &rarr;</a>
@@ -1121,7 +1121,7 @@
       <p class="section-intro">
         A certification is only worth what it can withstand. <strong>SHACKLE Certification</strong> proves &mdash; not
         promises &mdash; that a runtime correctly enforces the SP/1.0 mediation contract, measured against
-        <strong>14 public, hash-verifiable conformance fixtures</strong>. The same vectors that certify you are the ones
+        <strong>15 public, hash-verifiable conformance fixtures</strong>. The same vectors that certify you are the ones
         anyone can re-run to check the claim. No trust required.
       </p>
 
@@ -1165,26 +1165,34 @@
   </section>
 
   <section class="section section-dark">
-  <span class="section-label">// Testimonials</span>
-  <h2>What Developers Say.</h2>
+  <span class="section-label">// Evidence</span>
+  <h2>Don't Trust It. Re-Run It.</h2>
+  <p style="color:var(--gray);max-width:720px;">
+    SHACKLE's claims are built to be checked, not believed. Every one below is independently
+    verifiable from a clean clone &mdash; no quotes required.
+  </p>
 
-  <div class="testimonial">
-    <p class="quote">
-      "SHACKLE's litellm hook is brilliant for teams running polyglot stacks (CrewAI + AutoGen + LangGraph).
-      You get one unified guardrail across your whole topology."
-    </p>
-    <p class="attribution">
-      â Creator of <strong>TokenCircuit</strong>, competing LangGraph solution
-    </p>
-  </div>
-
-  <div class="testimonial">
-    <p class="quote">
-      "The error-amplification logic (catching 401/500s on the 2nd attempt) is incredibly sharp."
-    </p>
-    <p class="attribution">
-      â Developer on <strong>LangGraph</strong> issue tracker
-    </p>
+  <div class="standard-grid" style="margin-top:28px;">
+    <div class="standard-card">
+      <h4>Independently reproduced</h4>
+      <p>An independent developer (<strong>@nutstrut</strong>) reproduced <em>all</em> published
+      SP/1.0 fixture hashes from scratch and posted a runnable composition against the set &mdash;
+      <a href="https://github.com/crewAIInc/crewAI/issues/6025#issuecomment-4911510831" style="color:var(--orange);">public record</a>.
+      Not a testimonial &mdash; a reproduction.</p>
+    </div>
+    <div class="standard-card">
+      <h4>Reproducible conformance</h4>
+      <p>15 public, hash-verifiable fixtures behind a green CI pipeline. Clone the repo, run
+      <code>pytest tests/test_conformance.py</code>, and get the same verdicts &mdash;
+      <a href="https://github.com/Fame510/SHACKLE/blob/master/fixtures/conformance.json" style="color:var(--orange);">the fixtures are the proof</a>.</p>
+    </div>
+    <div class="standard-card">
+      <h4>The failure is documented</h4>
+      <p>The $106,000 runaway-agent incident is a public report
+      (<a href="https://github.com/microsoft/autogen/issues/7770" style="color:var(--orange);">microsoft/autogen#7770</a>),
+      not a hypothetical. SHACKLE's error-cascade breaker trips a repeated error-bearing call
+      (401/403/500/timeout) on its <strong>2nd</strong> attempt instead of the 3rd &mdash; verified in the suite.</p>
+    </div>
   </div>
 
   <div class="partner-banner">


### PR DESCRIPTION
## Summary
Two things, one merge: (1) sync the public landing page + spec docs with the shipped code, and (2) repair encoding corruption (mojibake) across the repo. No behavior change.

## Landing page + docs sync
- Fixture count **14 -> 15** (page, README, CONFORMANCE, fixtures/README); decision-core 9 -> 10.
- Landing install uses the install that works today (`pip install git+https://github.com/Fame510/SHACKLE.git`); PyPI package not yet published.
- Replaced two unverifiable testimonials with independently checkable evidence (independent fixture-hash reproduction on the public record, reproducible fixtures + green CI, the documented `microsoft/autogen#7770` incident); states the real, suite-verified error-cascade behavior.
- Corrected the landing "Honest scope" note: the `@Guard` runtime consults the reference `decide()` directly (shipped), matching README/CONFORMANCE.

## Encoding cleanup
- Repaired UTF-8 mojibake (garbled em-dashes, emojis, arrows) in `README.md`, `SP-1.0-SPECIFICATION.md`, `index.html`, `v2/spec/decide.py`, `v2/tests/test_conformance.py`. `fixtures/conformance.json` deliberately untouched (hash-covered). Repo-wide re-scan: 0 residual. Touched code compiles clean.
- De-linked the dead `TokenCircuit` URL (pointed at bare github.com).

## Noted, not in this PR
- `v2/landing/index.html` is a stale duplicate (pkg `shackle-guard`) — recommend deleting.
- `budget_overrun` deny reason not yet in CONFORMANCE normative text — a deliberate spec addition.
